### PR TITLE
Fix currency parsing and stabilize toast hook

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -171,6 +171,9 @@ function toast({ ...props }: Toast) {
 function useToast() {
   const [state, setState] = React.useState<State>(memoryState);
 
+  // Subscribe to toast state updates once on mount. The previous
+  // implementation re-subscribed on every state change which could lead
+  // to unnecessary re-renders and missed updates.
   React.useEffect(() => {
     listeners.push(setState);
     return () => {
@@ -179,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -21,5 +21,15 @@ export function formatCurrency(amount: number, currency = 'IDR'): string {
 }
 
 export function parseIDR(value: string): number {
-  return parseFloat(value.replace(/[^\d.-]/g, '')) || 0;
+  // IDR values are commonly formatted with thousand separators (.) and
+  // often omit a decimal portion. The previous implementation simply
+  // stripped non digits except for dots, causing values like
+  // `Rp 1.234.567` to be interpreted as `1.234` instead of `1234567`.
+  // Remove thousand separators and convert any decimal comma to a dot
+  // before parsing.
+  const sanitized = value
+    .replace(/\./g, '')
+    .replace(/[^0-9,-]/g, '')
+    .replace(',', '.');
+  return parseFloat(sanitized) || 0;
 }


### PR DESCRIPTION
## Summary
- fix parseIDR to handle thousand separators correctly
- subscribe toast hook only once to avoid redundant listeners

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install --force` *(fails: peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_689ab83250b88325ba6f59c7491772a8