### PR TITLE
Normalize dashboard data to camelCase

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -92,7 +92,7 @@ export default function SignInPage() {
 
             <div className="text-center">
               <p className="text-sm text-gray-600">
-                Don't have an account?{' '}
+                Don&apos;t have an account?{' '}
                 <Link href="/auth/signup" className="text-primary hover:underline">
                   Sign up
                 </Link>


### PR DESCRIPTION
## Summary
- convert Supabase responses to camelCase before storing
- use camelCase field names in dashboard calculations
- escape apostrophe on sign-in page to satisfy lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ac7fd778883258e68459716db8348