### PR TITLE
fix: allow chart component to skip type checking

### DIFF
--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -1,5 +1,5 @@
-'use client';
 // @ts-nocheck
+'use client';
 
 import * as React from 'react';
 import * as RechartsPrimitive from 'recharts';


### PR DESCRIPTION
## Summary
- ensure `@ts-nocheck` comment precedes the `'use client'` directive in chart component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Inter font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689acc7cd6988325af3af210f9b55af5