### PR TITLE
feat: add seeder for profile and account

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed": "node scripts/seed-user.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",

--- a/scripts/seed-user.mjs
+++ b/scripts/seed-user.mjs
@@ -1,0 +1,60 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceRoleKey) {
+  console.error('Missing Supabase environment variables');
+  process.exit(1);
+}
+
+const supabase = createClient(url, serviceRoleKey);
+
+async function seed() {
+  const email = 'awahid.safhadi@gmail.com';
+  const password = 'Pass123*#!';
+  const name = 'Awahid Safhadi';
+
+  const { data, error } = await supabase.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: { name },
+  });
+
+  if (error) {
+    throw new Error('Failed to create user: ' + error.message);
+  }
+
+  const user = data.user;
+
+  const { error: profileError } = await supabase.from('profiles').insert({
+    id: user.id,
+    email,
+    name,
+    default_currency: 'IDR',
+  });
+
+  if (profileError) {
+    throw new Error('Failed to create profile: ' + profileError.message);
+  }
+
+  const { error: accountError } = await supabase.from('accounts').insert({
+    user_id: user.id,
+    name: 'Cash',
+    type: 'cash',
+    currency: 'IDR',
+    opening_balance: 0,
+  });
+
+  if (accountError) {
+    throw new Error('Failed to create account: ' + accountError.message);
+  }
+
+  console.log('Seeded profile and account for', email);
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to seed a user profile and default cash account in Supabase
- expose a `npm run seed` command for convenient execution

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run seed` *(fails: Missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_689ad5f2daac8325bf7fbcbc1ed969ad