### PR TITLE
Fix dashboard loading and add placeholder pages

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -1,0 +1,9 @@
+export default function AccountsPage() {
+  return (
+    <div>
+      <h2 className="text-3xl font-bold tracking-tight">Accounts</h2>
+      <p className="text-muted-foreground">View and manage your accounts.</p>
+    </div>
+  );
+}
+

--- a/app/(dashboard)/budgets/page.tsx
+++ b/app/(dashboard)/budgets/page.tsx
@@ -1,0 +1,9 @@
+export default function BudgetsPage() {
+  return (
+    <div>
+      <h2 className="text-3xl font-bold tracking-tight">Budgets</h2>
+      <p className="text-muted-foreground">Manage your budgets.</p>
+    </div>
+  );
+}
+

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -15,7 +15,7 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   const router = useRouter();
-  const { user, setUser, setLoading } = useAppStore();
+  const { user, loading, setUser, setLoading } = useAppStore();
 
   useEffect(() => {
     const checkAuth = async () => {
@@ -52,12 +52,16 @@ export default function DashboardLayout({
     return () => subscription.unsubscribe();
   }, [router, setUser, setLoading]);
 
-  if (!user) {
+  if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary" />
       </div>
     );
+  }
+
+  if (!user) {
+    return null;
   }
 
   return (

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -1,0 +1,9 @@
+export default function ReportsPage() {
+  return (
+    <div>
+      <h2 className="text-3xl font-bold tracking-tight">Reports</h2>
+      <p className="text-muted-foreground">Financial reports will appear here.</p>
+    </div>
+  );
+}
+

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,9 @@
+export default function SettingsPage() {
+  return (
+    <div>
+      <h2 className="text-3xl font-bold tracking-tight">Settings</h2>
+      <p className="text-muted-foreground">Adjust your application preferences.</p>
+    </div>
+  );
+}
+

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -1,0 +1,9 @@
+export default function TransactionsPage() {
+  return (
+    <div>
+      <h2 className="text-3xl font-bold tracking-tight">Transactions</h2>
+      <p className="text-muted-foreground">Track your recent transactions.</p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- prevent infinite loading on dashboard by checking store loading state in layout
- add placeholder pages for budgets, transactions, accounts, reports, and settings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ad9ed501c8325999e3e4e1552e115