### PR TITLE
fix: mark loading spinner as client component

### DIFF
--- a/components/ui/loading-spinner.tsx
+++ b/components/ui/loading-spinner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 export function LoadingSpinner() {
   return (
     <div className="flex items-center justify-center min-h-[400px]">


### PR DESCRIPTION
## Summary
- mark LoadingSpinner as a client component so it can be used in client pages

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`...)*

------
https://chatgpt.com/codex/tasks/task_e_689ae003a98483258f0b651b91fd1771