### PR TITLE
fix build error by disabling swc minify

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   images: { unoptimized: true },
+  swcMinify: false,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- disable SWC minification to avoid invalid code generation during build

## Testing
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689ae234f6fc832599f71443d8896f99