### PR TITLE
feat: enhance dashboard filters and charts

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -42,7 +42,19 @@ function keysToCamel<T>(obj: any): T {
 }
 
 export default function DashboardPage() {
-  const { user, accounts, transactions, budgets, setAccounts, setTransactions, setBudgets, setCategories, loading, setLoading } = useAppStore();
+  const {
+    user,
+    accounts,
+    categories,
+    transactions,
+    budgets,
+    setAccounts,
+    setTransactions,
+    setBudgets,
+    setCategories,
+    loading,
+    setLoading,
+  } = useAppStore();
   const [kpis, setKpis] = useState<DashboardKPIs>({
     totalBalance: 0,
     monthlyBudget: 0,
@@ -271,13 +283,17 @@ export default function DashboardPage() {
       </div>
 
       {/* Charts */}
-      <DashboardCharts 
+      <DashboardCharts
         transactions={transactions}
         categorySpends={categorySpends}
       />
 
       {/* Recent Transactions */}
-      <RecentTransactions transactions={transactions.slice(0, 10)} />
+      <RecentTransactions
+        transactions={transactions}
+        accounts={accounts}
+        categories={categories}
+      />
     </div>
   );
 }

--- a/components/dashboard/dashboard-charts.tsx
+++ b/components/dashboard/dashboard-charts.tsx
@@ -2,27 +2,23 @@
 // @ts-nocheck
 
 import { useMemo } from 'react';
-import { 
-  LineChart, 
-  Line, 
-  AreaChart, 
-  Area, 
-  BarChart, 
-  Bar, 
-  PieChart, 
-  Pie, 
+import {
+  AreaChart,
+  Area,
+  PieChart,
+  Pie,
   Cell,
-  XAxis, 
-  YAxis, 
-  CartesianGrid, 
-  Tooltip, 
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
   ResponsiveContainer,
   Legend
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Transaction, CategorySpend } from '@/types';
 import { formatIDR } from '@/lib/currency';
-import { format, parseISO, eachDayOfInterval, startOfMonth, endOfMonth } from 'date-fns';
+import { format, eachDayOfInterval, startOfMonth, endOfMonth } from 'date-fns';
 
 interface Props {
   transactions: Transaction[];
@@ -49,15 +45,6 @@ export function DashboardCharts({ transactions, categorySpends }: Props) {
     });
   }, [transactions]);
 
-  const categoryComparisonData = useMemo(() => {
-    return categorySpends.map(category => ({
-      name: category.categoryName,
-      budgeted: category.budgeted,
-      actual: category.amount,
-      color: category.color,
-    }));
-  }, [categorySpends]);
-
   const categoryPieData = useMemo(() => {
     return categorySpends
       .filter(c => c.amount > 0)
@@ -69,9 +56,9 @@ export function DashboardCharts({ transactions, categorySpends }: Props) {
   }, [categorySpends]);
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <div className="grid gap-4 lg:grid-cols-2">
       {/* Daily Expenses Line Chart */}
-      <Card className="col-span-full lg:col-span-2">
+      <Card className="lg:col-span-1">
         <CardHeader>
           <CardTitle>Daily Expenses (Current Month)</CardTitle>
         </CardHeader>
@@ -106,7 +93,7 @@ export function DashboardCharts({ transactions, categorySpends }: Props) {
       </Card>
 
       {/* Category Pie Chart */}
-      <Card>
+      <Card className="lg:col-span-1">
         <CardHeader>
           <CardTitle>Expense by Category</CardTitle>
         </CardHeader>
@@ -135,37 +122,6 @@ export function DashboardCharts({ transactions, categorySpends }: Props) {
         </CardContent>
       </Card>
 
-      {/* Category Comparison Bar Chart */}
-      <Card className="col-span-full">
-        <CardHeader>
-          <CardTitle>Budget vs Actual by Category</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="h-80">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={categoryComparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis 
-                  dataKey="name" 
-                  angle={-45}
-                  textAnchor="end"
-                  height={80}
-                />
-                <YAxis tickFormatter={(value) => formatIDR(value)} />
-                <Tooltip 
-                  formatter={(value: number, name: string) => [
-                    formatIDR(value), 
-                    name === 'budgeted' ? 'Budgeted' : 'Actual'
-                  ]}
-                />
-                <Legend />
-                <Bar dataKey="budgeted" fill="#10B981" name="Budgeted" />
-                <Bar dataKey="actual" fill="#3B82F6" name="Actual" />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -1,17 +1,59 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Transaction } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Transaction, Account, Category } from '@/types';
 import { formatIDR } from '@/lib/currency';
 import { format, parseISO } from 'date-fns';
-import { ArrowUpRight, ArrowDownLeft, ArrowRightLeft } from 'lucide-react';
+import { ArrowUpRight, ArrowDownLeft, ArrowRightLeft, Filter } from 'lucide-react';
 
 interface Props {
   transactions: Transaction[];
+  accounts: Account[];
+  categories: Category[];
 }
 
-export function RecentTransactions({ transactions }: Props) {
+export function RecentTransactions({ transactions, accounts, categories }: Props) {
+  const [open, setOpen] = useState(false);
+  const [filters, setFilters] = useState({
+    startDate: '',
+    endDate: '',
+    accountId: '',
+    categoryId: '',
+    type: '',
+  });
+
+  const filteredTransactions = useMemo(() => {
+    return transactions.filter(t => {
+      if (filters.startDate && t.date < filters.startDate) return false;
+      if (filters.endDate && t.date > filters.endDate) return false;
+      if (filters.accountId) {
+        const matchesAccount =
+          t.accountId === filters.accountId ||
+          t.fromAccountId === filters.accountId ||
+          t.toAccountId === filters.accountId;
+        if (!matchesAccount) return false;
+      }
+      if (filters.categoryId && t.categoryId !== filters.categoryId) return false;
+      if (filters.type && t.type !== filters.type) return false;
+      return true;
+    });
+  }, [transactions, filters]);
   const getTransactionIcon = (type: string) => {
     switch (type) {
       case 'income':
@@ -47,76 +89,148 @@ export function RecentTransactions({ transactions }: Props) {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Recent Transactions</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          {transactions.length === 0 ? (
-            <p className="text-sm text-muted-foreground text-center py-4">
-              No transactions yet. Start by adding your first transaction.
-            </p>
-          ) : (
-            transactions.map((transaction) => (
-              <div
-                key={transaction.id}
-                className="flex items-center justify-between p-3 rounded-lg border"
+      <Collapsible open={open} onOpenChange={setOpen} className="w-full">
+        <CardHeader className="space-y-2">
+          <div className="flex items-center justify-between">
+            <CardTitle>Recent Transactions</CardTitle>
+            <CollapsibleTrigger asChild>
+              <Button variant="outline" size="sm">
+                <Filter className="mr-2 h-4 w-4" />
+                {open ? 'Hide' : 'Filters'}
+              </Button>
+            </CollapsibleTrigger>
+          </div>
+          <CollapsibleContent className="pt-4">
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+              <Input
+                type="date"
+                value={filters.startDate}
+                onChange={e => setFilters(f => ({ ...f, startDate: e.target.value }))}
+              />
+              <Input
+                type="date"
+                value={filters.endDate}
+                onChange={e => setFilters(f => ({ ...f, endDate: e.target.value }))}
+              />
+              <Select
+                value={filters.accountId}
+                onValueChange={value => setFilters(f => ({ ...f, accountId: value }))}
               >
-                <div className="flex items-center space-x-3">
-                  {getTransactionIcon(transaction.type)}
-                  <div>
-                    <p className="text-sm font-medium">
-                      {getTransactionDescription(transaction)}
-                    </p>
-                    <div className="flex items-center space-x-2 mt-1">
-                      <p className="text-xs text-muted-foreground">
-                        {format(parseISO(transaction.date), 'MMM dd, yyyy')}
+                <SelectTrigger>
+                  <SelectValue placeholder="Account" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">All Accounts</SelectItem>
+                  {accounts.map(acc => (
+                    <SelectItem key={acc.id} value={acc.id}>
+                      {acc.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select
+                value={filters.categoryId}
+                onValueChange={value => setFilters(f => ({ ...f, categoryId: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Category" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">All Categories</SelectItem>
+                  {categories.map(cat => (
+                    <SelectItem key={cat.id} value={cat.id}>
+                      {cat.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select
+                value={filters.type}
+                onValueChange={value => setFilters(f => ({ ...f, type: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">All Types</SelectItem>
+                  <SelectItem value="income">Income</SelectItem>
+                  <SelectItem value="expense">Expense</SelectItem>
+                  <SelectItem value="transfer">Transfer</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </CollapsibleContent>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {filteredTransactions.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-4">
+                No transactions found.
+              </p>
+            ) : (
+              filteredTransactions.map(transaction => (
+                <div
+                  key={transaction.id}
+                  className="flex items-center justify-between p-3 rounded-lg border"
+                >
+                  <div className="flex items-center space-x-3">
+                    {getTransactionIcon(transaction.type)}
+                    <div>
+                      <p className="text-sm font-medium">
+                        {getTransactionDescription(transaction)}
                       </p>
-                      {transaction.account && (
-                        <Badge variant="outline" className="text-xs">
-                          {transaction.account.name}
-                        </Badge>
-                      )}
-                      {transaction.tags && transaction.tags.length > 0 && (
-                        <div className="flex space-x-1">
-                          {transaction.tags.slice(0, 2).map(tag => (
-                            <Badge key={tag} variant="secondary" className="text-xs">
-                              {tag}
-                            </Badge>
-                          ))}
-                          {transaction.tags.length > 2 && (
-                            <Badge variant="secondary" className="text-xs">
-                              +{transaction.tags.length - 2}
-                            </Badge>
-                          )}
-                        </div>
-                      )}
+                      <div className="flex items-center space-x-2 mt-1">
+                        <p className="text-xs text-muted-foreground">
+                          {format(parseISO(transaction.date), 'MMM dd, yyyy')}
+                        </p>
+                        {transaction.account && (
+                          <Badge variant="outline" className="text-xs">
+                            {transaction.account.name}
+                          </Badge>
+                        )}
+                        {transaction.tags && transaction.tags.length > 0 && (
+                          <div className="flex space-x-1">
+                            {transaction.tags.slice(0, 2).map(tag => (
+                              <Badge key={tag} variant="secondary" className="text-xs">
+                                {tag}
+                              </Badge>
+                            ))}
+                            {transaction.tags.length > 2 && (
+                              <Badge variant="secondary" className="text-xs">
+                                +{transaction.tags.length - 2}
+                              </Badge>
+                            )}
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
+                  <div className="text-right">
+                    <p
+                      className={`text-sm font-semibold ${
+                        transaction.type === 'income'
+                          ? 'text-green-600'
+                          : transaction.type === 'expense'
+                          ? 'text-red-600'
+                          : 'text-blue-600'
+                      }`}
+                    >
+                      {transaction.type === 'expense' ? '-' : ''}
+                      {formatIDR(transaction.amount)}
+                    </p>
+                    <Badge
+                      variant={getTransactionBadgeVariant(transaction.type)}
+                      className="text-xs mt-1"
+                    >
+                      {transaction.type}
+                    </Badge>
+                  </div>
                 </div>
-                <div className="text-right">
-                  <p className={`text-sm font-semibold ${
-                    transaction.type === 'income' 
-                      ? 'text-green-600' 
-                      : transaction.type === 'expense'
-                      ? 'text-red-600'
-                      : 'text-blue-600'
-                  }`}>
-                    {transaction.type === 'expense' ? '-' : ''}
-                    {formatIDR(transaction.amount)}
-                  </p>
-                  <Badge 
-                    variant={getTransactionBadgeVariant(transaction.type)}
-                    className="text-xs mt-1"
-                  >
-                    {transaction.type}
-                  </Badge>
-                </div>
-              </div>
-            ))
-          )}
-        </div>
-      </CardContent>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </Collapsible>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- streamline dashboard to show daily expenses line chart and category donut chart
- add collapsible filters to recent transactions (date, account, category, type)
- pass account and category data to transactions for filtering

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ae43ca7708325a8d6c0ce95ee13fc