### PR TITLE
Implement account management UI

### DIFF
--- a/app/(dashboard)/accounts/[id]/edit/page.tsx
+++ b/app/(dashboard)/accounts/[id]/edit/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+
+import { Account } from '@/types';
+import { supabase } from '@/lib/supabase';
+import { useAppStore } from '@/lib/store';
+import { AccountForm } from '@/components/accounts/account-form';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+
+const toCamel = (str: string) =>
+  str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+
+function keysToCamel<T>(obj: any): T {
+  if (Array.isArray(obj)) {
+    return obj.map((v) => keysToCamel(v)) as any;
+  }
+  if (obj && typeof obj === 'object' && obj.constructor === Object) {
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[toCamel(key)] = keysToCamel(value);
+    }
+    return result as T;
+  }
+  return obj as T;
+}
+
+export default function EditAccountPage() {
+  const params = useParams<{ id: string }>();
+  const { accounts } = useAppStore();
+  const [account, setAccount] = useState<Account | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const existing = accounts.find((a) => a.id === params.id);
+    if (existing) {
+      setAccount(existing);
+      setLoading(false);
+    } else {
+      const fetchAccount = async () => {
+        const { data } = await supabase
+          .from('accounts')
+          .select('*')
+          .eq('id', params.id)
+          .single();
+        if (data) setAccount(keysToCamel<Account>(data));
+        setLoading(false);
+      };
+      fetchAccount();
+    }
+  }, [params.id, accounts]);
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (!account) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight">Edit Account</h2>
+        <p className="text-muted-foreground">Update account details.</p>
+      </div>
+      <AccountForm account={account} />
+    </div>
+  );
+}
+

--- a/app/(dashboard)/accounts/new/page.tsx
+++ b/app/(dashboard)/accounts/new/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { AccountForm } from '@/components/accounts/account-form';
+
+export default function NewAccountPage() {
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight">Add Account</h2>
+        <p className="text-muted-foreground">Create a new account.</p>
+      </div>
+      <AccountForm />
+    </div>
+  );
+}
+

--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -1,8 +1,216 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import {
+  Building2,
+  Smartphone,
+  Wallet2,
+  MoreHorizontal,
+  Plus,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+import { useAppStore } from '@/lib/store';
+import { supabase } from '@/lib/supabase';
+import { formatCurrency } from '@/lib/currency';
+import { Account, Transaction } from '@/types';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+
+const typeIcons = {
+  bank: Building2,
+  ewallet: Smartphone,
+  cash: Wallet2,
+};
+
+const toCamel = (str: string) =>
+  str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+
+function keysToCamel<T>(obj: any): T {
+  if (Array.isArray(obj)) {
+    return obj.map((v) => keysToCamel(v)) as any;
+  }
+  if (obj && typeof obj === 'object' && obj.constructor === Object) {
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[toCamel(key)] = keysToCamel(value);
+    }
+    return result as T;
+  }
+  return obj as T;
+}
+
 export default function AccountsPage() {
+  const {
+    user,
+    accounts,
+    transactions,
+    setAccounts,
+    setTransactions,
+    loading,
+    setLoading,
+    getCurrentBalance,
+  } = useAppStore();
+
+  useEffect(() => {
+    if (!user) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const { data: accountsData } = await supabase
+          .from('accounts')
+          .select('*')
+          .eq('user_id', user.id);
+        if (accountsData) setAccounts(keysToCamel<Account[]>(accountsData));
+
+        if (!transactions.length) {
+          const { data: txData } = await supabase
+            .from('transactions')
+            .select('*')
+            .eq('user_id', user.id);
+          if (txData) setTransactions(keysToCamel<Transaction[]>(txData));
+        }
+      } catch (error) {
+        console.error('Failed to fetch accounts:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [user, setAccounts, setTransactions, transactions.length, setLoading]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      const { error } = await supabase.from('accounts').delete().eq('id', id);
+      if (error) throw error;
+      setAccounts(accounts.filter((a) => a.id !== id));
+      toast.success('Account deleted');
+    } catch (err) {
+      console.error('Failed to delete account:', err);
+      toast.error('Failed to delete account');
+    }
+  };
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
   return (
-    <div>
-      <h2 className="text-3xl font-bold tracking-tight">Accounts</h2>
-      <p className="text-muted-foreground">View and manage your accounts.</p>
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">Accounts</h2>
+          <p className="text-muted-foreground">View and manage your accounts.</p>
+        </div>
+        <div className="hidden md:block">
+          <Link href="/accounts/new">
+            <Button className="transition-transform hover:scale-105">
+              Add Account
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {accounts.map((account) => {
+          const Icon = typeIcons[account.type];
+          const balance = getCurrentBalance(account.id);
+          return (
+            <Card
+              key={account.id}
+              className="bg-muted/50 hover:shadow-md transition-shadow"
+            >
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle className="flex items-center space-x-2">
+                  <Icon className="h-5 w-5" />
+                  <span>{account.name}</span>
+                  {account.archived && (
+                    <Badge variant="secondary">Archived</Badge>
+                  )}
+                </CardTitle>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon">
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem asChild>
+                      <Link href={`/accounts/${account.id}/edit`}>Edit</Link>
+                    </DropdownMenuItem>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <DropdownMenuItem className="text-destructive">
+                          Delete
+                        </DropdownMenuItem>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>
+                            Delete account?
+                          </AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This action cannot be undone.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => handleDelete(account.id)}
+                          >
+                            Delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  {formatCurrency(balance, account.currency)}
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {account.currency}
+                </p>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      <Link href="/accounts/new" className="md:hidden fixed bottom-6 right-6">
+        <Button className="h-12 w-12 rounded-full p-0 shadow-lg transition-transform hover:scale-105">
+          <Plus className="h-6 w-6" />
+        </Button>
+      </Link>
     </div>
   );
 }

--- a/components/accounts/account-form.tsx
+++ b/components/accounts/account-form.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { toast } from 'sonner';
+
+import { useAppStore } from '@/lib/store';
+import { supabase } from '@/lib/supabase';
+import { Account } from '@/types';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+
+const accountSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  type: z.enum(['bank', 'ewallet', 'cash']),
+  currency: z.string().min(1, 'Currency is required'),
+  openingBalance: z.coerce.number(),
+  archived: z.boolean().optional(),
+});
+
+type AccountFormValues = z.infer<typeof accountSchema>;
+
+interface AccountFormProps {
+  account?: Account;
+}
+
+export function AccountForm({ account }: AccountFormProps) {
+  const router = useRouter();
+  const { user, accounts, setAccounts } = useAppStore();
+
+  const form = useForm<AccountFormValues>({
+    resolver: zodResolver(accountSchema),
+    defaultValues: {
+      name: account?.name ?? '',
+      type: account?.type ?? 'bank',
+      currency: account?.currency ?? 'IDR',
+      openingBalance: account?.openingBalance ?? 0,
+      archived: account?.archived ?? false,
+    },
+  });
+
+  const onSubmit = async (values: AccountFormValues) => {
+    if (!user) return;
+    try {
+      if (account) {
+        const { error } = await supabase
+          .from('accounts')
+          .update({
+            name: values.name,
+            type: values.type,
+            currency: values.currency,
+            opening_balance: values.openingBalance,
+            archived: values.archived,
+          })
+          .eq('id', account.id);
+        if (error) throw error;
+        setAccounts(
+          accounts.map((a) =>
+            a.id === account.id ? { ...a, ...values } : a
+          )
+        );
+        toast.success('Account updated');
+      } else {
+        const { data, error } = await supabase
+          .from('accounts')
+          .insert({
+            user_id: user.id,
+            name: values.name,
+            type: values.type,
+            currency: values.currency,
+            opening_balance: values.openingBalance,
+            archived: values.archived,
+          })
+          .select()
+          .single();
+        if (error) throw error;
+        const newAccount: Account = {
+          id: data.id,
+          userId: data.user_id,
+          name: data.name,
+          type: data.type,
+          currency: data.currency,
+          openingBalance: data.opening_balance,
+          archived: data.archived,
+        };
+        setAccounts([...accounts, newAccount]);
+        toast.success('Account created');
+      }
+      router.push('/accounts');
+    } catch (err) {
+      console.error('Failed to save account:', err);
+      toast.error('Failed to save account');
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Type</FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select type" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="bank">Bank</SelectItem>
+                  <SelectItem value="ewallet">E-Wallet</SelectItem>
+                  <SelectItem value="cash">Cash</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="currency"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Currency</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="openingBalance"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Opening Balance</FormLabel>
+              <FormControl>
+                <Input type="number" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="archived"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+              <FormControl>
+                <Checkbox
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+              <div className="space-y-1 leading-none">
+                <FormLabel>Archived</FormLabel>
+              </div>
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full">
+          {account ? 'Update' : 'Create'} Account
+        </Button>
+      </form>
+    </Form>
+  );
+}
+
+export default AccountForm;
+


### PR DESCRIPTION
## Summary
- display accounts in responsive grid with type icons, balances, currency, archived badge, and edit/delete actions
- add reusable AccountForm and pages for creating and editing accounts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ae47e6df083258fd4129de119d2f0