### PR TITLE
feat: add transaction listing with filters and form

### DIFF
--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -1,8 +1,440 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { format, parseISO } from 'date-fns';
+import * as LucideIcons from 'lucide-react';
+import { Plus, Pencil, Trash, Calendar as CalendarIcon } from 'lucide-react';
+
+import { useAppStore } from '@/lib/store';
+import { supabase } from '@/lib/supabase';
+import { formatIDR } from '@/lib/currency';
+import { cn } from '@/lib/utils';
+import { Transaction, Account, Category } from '@/types';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+
+import TransactionForm, {
+  TransactionFormValues,
+} from '@/components/transactions/transaction-form';
+
+interface DateRange {
+  from?: Date;
+  to?: Date;
+}
+
+const toCamel = (str: string) =>
+  str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+
+function keysToCamel<T>(obj: any): T {
+  if (Array.isArray(obj)) {
+    return obj.map((v) => keysToCamel(v)) as any;
+  }
+  if (obj && typeof obj === 'object' && obj.constructor === Object) {
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[toCamel(key)] = keysToCamel(value);
+    }
+    return result as T;
+  }
+  return obj as T;
+}
+
 export default function TransactionsPage() {
+  const {
+    user,
+    accounts,
+    categories,
+    transactions,
+    setAccounts,
+    setCategories,
+    setTransactions,
+  } = useAppStore();
+
+  const [dateRange, setDateRange] = useState<DateRange>({});
+  const [accountFilter, setAccountFilter] = useState('all');
+  const [categoryFilter, setCategoryFilter] = useState('all');
+  const [typeFilter, setTypeFilter] = useState('all');
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Transaction | undefined>();
+
+  useEffect(() => {
+    if (!user) return;
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  const fetchData = async () => {
+    try {
+
+      if (!accounts.length) {
+        const { data: accountsData } = await supabase
+          .from('accounts')
+          .select('*')
+          .eq('user_id', user!.id)
+          .eq('archived', false);
+        if (accountsData) setAccounts(keysToCamel<Account[]>(accountsData));
+      }
+      if (!categories.length) {
+        const { data: categoriesData } = await supabase
+          .from('categories')
+          .select('*')
+          .eq('user_id', user!.id);
+        if (categoriesData) setCategories(keysToCamel<Category[]>(categoriesData));
+      }
+      await fetchTransactions();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const fetchTransactions = async () => {
+    if (!user) return;
+    const { data } = await supabase
+      .from('transactions')
+      .select(
+        `*,
+        account:accounts(name, type),
+        from_account:accounts!transactions_from_account_id_fkey(name, type),
+        to_account:accounts!transactions_to_account_id_fkey(name, type),
+        category:categories(name, color, icon)`
+      )
+      .eq('user_id', user.id)
+      .order('date', { ascending: false });
+    if (data) setTransactions(keysToCamel<Transaction[]>(data));
+  };
+
+  const handleSave = async (values: TransactionFormValues) => {
+    if (!user) return;
+    const payload = {
+      user_id: user.id,
+      date: values.date.toISOString().split('T')[0],
+      type: values.type,
+      account_id: values.accountId,
+      from_account_id: values.fromAccountId,
+      to_account_id: values.toAccountId,
+      category_id: values.categoryId,
+      amount: values.amount,
+      note: values.note,
+      tags: [],
+    };
+    if (editing) {
+      await supabase.from('transactions').update(payload).eq('id', editing.id);
+    } else {
+      await supabase.from('transactions').insert(payload);
+    }
+    await fetchTransactions();
+    setFormOpen(false);
+    setEditing(undefined);
+  };
+
+  const handleDelete = async () => {
+    if (!editing) return;
+    await supabase.from('transactions').delete().eq('id', editing.id);
+    await fetchTransactions();
+    setFormOpen(false);
+    setEditing(undefined);
+  };
+
+  const handleDeleteRow = async (t: Transaction) => {
+    await supabase.from('transactions').delete().eq('id', t.id);
+    await fetchTransactions();
+  };
+
+  const openNew = () => {
+    setEditing(undefined);
+    setFormOpen(true);
+  };
+
+  const openEdit = (t: Transaction) => {
+    setEditing(t);
+    setFormOpen(true);
+  };
+
+  const filteredTransactions = transactions.filter((t) => {
+    const dateOk =
+      (!dateRange.from || new Date(t.date) >= dateRange.from) &&
+      (!dateRange.to || new Date(t.date) <= dateRange.to);
+    const accountOk =
+      accountFilter === 'all' ||
+      t.accountId === accountFilter ||
+      t.fromAccountId === accountFilter ||
+      t.toAccountId === accountFilter;
+    const categoryOk =
+      categoryFilter === 'all' || t.categoryId === categoryFilter;
+    const typeOk = typeFilter === 'all' || t.type === typeFilter;
+    return dateOk && accountOk && categoryOk && typeOk;
+  });
+
   return (
-    <div>
-      <h2 className="text-3xl font-bold tracking-tight">Transactions</h2>
-      <p className="text-muted-foreground">Track your recent transactions.</p>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">Transactions</h2>
+          <p className="text-muted-foreground">Track your recent transactions.</p>
+        </div>
+        <Button className="hidden md:flex" onClick={openNew}>
+          <Plus className="mr-2 h-4 w-4" /> Add Transaction
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-2">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              className={cn(
+                'w-[250px] justify-start',
+                !dateRange.from && 'text-muted-foreground'
+              )}
+            >
+              {dateRange.from ? (
+                dateRange.to ? (
+                  `${format(dateRange.from, 'LLL dd, yyyy')} - ${format(
+                    dateRange.to,
+                    'LLL dd, yyyy'
+                  )}`
+                ) : (
+                  format(dateRange.from, 'LLL dd, yyyy')
+                )
+              ) : (
+                <span>Pick dates</span>
+              )}
+              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="range"
+              selected={dateRange}
+              onSelect={setDateRange}
+              numberOfMonths={2}
+            />
+          </PopoverContent>
+        </Popover>
+
+        <Select value={accountFilter} onValueChange={setAccountFilter}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Account" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Accounts</SelectItem>
+            {accounts.map((a) => (
+              <SelectItem key={a.id} value={a.id}>
+                {a.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Category" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Categories</SelectItem>
+            {categories.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={typeFilter} onValueChange={setTypeFilter}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Types</SelectItem>
+            <SelectItem value="expense">Expense</SelectItem>
+            <SelectItem value="income">Income</SelectItem>
+            <SelectItem value="transfer">Transfer</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Desktop Table */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10" />
+              <TableHead>Title</TableHead>
+              <TableHead>Date</TableHead>
+              <TableHead>Account</TableHead>
+              <TableHead className="text-right">Amount</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredTransactions.map((t) => {
+              const Icon = t.category?.icon
+                ? (LucideIcons[
+                    t.category.icon as keyof typeof LucideIcons
+                  ] as any)
+                : null;
+              const title =
+                t.note ||
+                t.category?.name ||
+                (t.type === 'transfer'
+                  ? `Transfer from ${t.fromAccount?.name} to ${t.toAccount?.name}`
+                  : 'No description');
+              const color =
+                t.type === 'income'
+                  ? 'text-green-600'
+                  : t.type === 'expense'
+                  ? 'text-red-600'
+                  : 'text-blue-600';
+              const amountPrefix = t.type === 'expense' ? '-' : '';
+              return (
+                <TableRow key={t.id}>
+                  <TableCell className="p-0">
+                    {Icon && (
+                      <Icon
+                        className="h-4 w-4"
+                        color={t.category?.color}
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell>{title}</TableCell>
+                  <TableCell>
+                    {format(parseISO(t.date), 'MMM dd, yyyy')}
+                  </TableCell>
+                  <TableCell>
+                    {t.account?.name ||
+                      t.fromAccount?.name ||
+                      t.toAccount?.name ||
+                      '-'}
+                  </TableCell>
+                  <TableCell className={cn('text-right font-medium', color)}>
+                    {amountPrefix}
+                    {formatIDR(t.amount)}
+                  </TableCell>
+                  <TableCell className="text-right space-x-2">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => openEdit(t)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleDeleteRow(t)}
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile Cards */}
+      <div className="md:hidden space-y-2">
+        {filteredTransactions.map((t) => {
+          const Icon = t.category?.icon
+            ? (LucideIcons[t.category.icon as keyof typeof LucideIcons] as any)
+            : null;
+          const title =
+            t.note ||
+            t.category?.name ||
+            (t.type === 'transfer'
+              ? `Transfer from ${t.fromAccount?.name} to ${t.toAccount?.name}`
+              : 'No description');
+          const color =
+            t.type === 'income'
+              ? 'text-green-600'
+              : t.type === 'expense'
+              ? 'text-red-600'
+              : 'text-blue-600';
+          const amountPrefix = t.type === 'expense' ? '-' : '';
+          return (
+            <Card
+              key={t.id}
+              className="p-4 flex items-center justify-between"
+            >
+              <div className="flex items-center space-x-3">
+                {Icon && <Icon className="h-5 w-5" color={t.category?.color} />}
+                <div>
+                  <p className="text-sm font-medium">{title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {format(parseISO(t.date), 'MMM dd, yyyy')}
+                  </p>
+                </div>
+              </div>
+              <div className="text-right">
+                <p className={cn('text-sm font-semibold', color)}>
+                  {amountPrefix}
+                  {formatIDR(t.amount)}
+                </p>
+                <div className="flex justify-end space-x-1 mt-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => openEdit(t)}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleDeleteRow(t)}
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+
+      <Button
+        onClick={openNew}
+        className="md:hidden fixed bottom-6 right-6 rounded-full h-14 w-14 p-0"
+      >
+        <Plus className="h-6 w-6" />
+      </Button>
+
+      <TransactionForm
+        open={formOpen}
+        onOpenChange={(o) => {
+          if (!o) setEditing(undefined);
+          setFormOpen(o);
+        }}
+        transaction={editing}
+        accounts={accounts}
+        categories={categories}
+        onSubmit={handleSave}
+        onDelete={editing ? handleDelete : undefined}
+      />
     </div>
   );
 }

--- a/components/transactions/transaction-form.tsx
+++ b/components/transactions/transaction-form.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+
+import { Account, Category, Transaction } from '@/types';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { cn } from '@/lib/utils';
+import { format } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+
+const formSchema = z.object({
+  date: z.date(),
+  type: z.enum(['expense', 'income', 'transfer']),
+  accountId: z.string().optional(),
+  fromAccountId: z.string().optional(),
+  toAccountId: z.string().optional(),
+  categoryId: z.string().optional(),
+  amount: z.coerce.number(),
+  note: z.string().optional(),
+});
+
+export type TransactionFormValues = z.infer<typeof formSchema>;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  transaction?: Transaction;
+  accounts: Account[];
+  categories: Category[];
+  onSubmit: (values: TransactionFormValues) => Promise<void>;
+  onDelete?: () => Promise<void>;
+}
+
+export function TransactionForm({
+  open,
+  onOpenChange,
+  transaction,
+  accounts,
+  categories,
+  onSubmit,
+  onDelete,
+}: Props) {
+  const form = useForm<TransactionFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      date: new Date(),
+      type: 'expense',
+      accountId: undefined,
+      fromAccountId: undefined,
+      toAccountId: undefined,
+      categoryId: undefined,
+      amount: 0,
+      note: '',
+    },
+  });
+
+  useEffect(() => {
+    if (transaction) {
+      form.reset({
+        date: new Date(transaction.date),
+        type: transaction.type,
+        accountId: transaction.accountId,
+        fromAccountId: transaction.fromAccountId,
+        toAccountId: transaction.toAccountId,
+        categoryId: transaction.categoryId,
+        amount: transaction.amount,
+        note: transaction.note || '',
+      });
+    } else {
+      form.reset({
+        date: new Date(),
+        type: 'expense',
+        amount: 0,
+        note: '',
+      });
+    }
+  }, [transaction, form]);
+
+  const handleSubmit = async (values: TransactionFormValues) => {
+    await onSubmit(values);
+    form.reset({
+      date: new Date(),
+      type: 'expense',
+      amount: 0,
+      note: '',
+    });
+  };
+
+  const currentType = form.watch('type');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-screen overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{transaction ? 'Edit Transaction' : 'Add Transaction'}</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="date"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>Date</FormLabel>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant="outline"
+                          className={cn(
+                            'w-full justify-start text-left font-normal',
+                            !field.value && 'text-muted-foreground'
+                          )}
+                        >
+                          {field.value ? (
+                            format(field.value, 'PPP')
+                          ) : (
+                            <span>Pick a date</span>
+                          )}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={field.value}
+                        onSelect={field.onChange}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="expense">Expense</SelectItem>
+                      <SelectItem value="income">Income</SelectItem>
+                      <SelectItem value="transfer">Transfer</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {currentType !== 'transfer' ? (
+              <FormField
+                control={form.control}
+                name="accountId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Account</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select account" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {accounts.map((a) => (
+                          <SelectItem key={a.id} value={a.id}>
+                            {a.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="fromAccountId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>From Account</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select account" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {accounts.map((a) => (
+                            <SelectItem key={a.id} value={a.id}>
+                              {a.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="toAccountId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>To Account</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select account" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {accounts.map((a) => (
+                            <SelectItem key={a.id} value={a.id}>
+                              {a.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+
+            {currentType !== 'transfer' && (
+              <FormField
+                control={form.control}
+                name="categoryId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Category</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select category" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {categories
+                          .filter((c) => c.type === currentType)
+                          .map((c) => (
+                            <SelectItem key={c.id} value={c.id}>
+                              {c.name}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Amount</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="note"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Note</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              {transaction && onDelete && (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => onDelete()}
+                >
+                  Delete
+                </Button>
+              )}
+              <Button type="submit">
+                {transaction ? 'Update' : 'Add'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default TransactionForm;
+


### PR DESCRIPTION
## Summary
- implement responsive transaction list with date range, account, category and type filters
- add CRUD handlers and floating action button for mobile
- introduce shadcn-powered dialog form for adding/editing transactions

## Testing
- `npm run lint`
- `npm run build` (fails: fetch failed ENETUNREACH)

------
https://chatgpt.com/codex/tasks/task_e_689ae460e894832597cfde83d620729c