### PR TITLE
fix: import DateRange type for transaction calendar

### DIFF
--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -34,7 +34,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Calendar } from '@/components/ui/calendar';
-import type { DateRange } from 'react-day-picker';
+import type { DateRange, SelectRangeEventHandler } from 'react-day-picker';
 
 import TransactionForm, {
   TransactionFormValues,
@@ -72,6 +72,10 @@ export default function TransactionsPage() {
     from: undefined,
     to: undefined,
   });
+
+  const handleDateRangeSelect: SelectRangeEventHandler = (range) => {
+    setDateRange(range ?? { from: undefined, to: undefined });
+  };
   const [accountFilter, setAccountFilter] = useState('all');
   const [categoryFilter, setCategoryFilter] = useState('all');
   const [typeFilter, setTypeFilter] = useState('all');
@@ -228,7 +232,7 @@ export default function TransactionsPage() {
             <Calendar
               mode="range"
               selected={dateRange}
-              onSelect={setDateRange}
+              onSelect={handleDateRangeSelect}
               numberOfMonths={2}
             />
           </PopoverContent>


### PR DESCRIPTION
## Summary
- use `DateRange` from `react-day-picker` instead of a local interface
- initialize transaction date range with explicit from/to properties

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed for SWC download)*

------
https://chatgpt.com/codex/tasks/task_e_689ae9362cf08325be1895ca46d35537