### PR TITLE
fix account form resolver types

### DIFF
--- a/components/accounts/account-form.tsx
+++ b/components/accounts/account-form.tsx
@@ -46,7 +46,7 @@ export function AccountForm({ account }: AccountFormProps) {
   const router = useRouter();
   const { user, accounts, setAccounts } = useAppStore();
 
-  const form = useForm<AccountFormValues>({
+  const form = useForm<z.input<typeof accountSchema>, any, AccountFormValues>({
     resolver: zodResolver(accountSchema),
     defaultValues: {
       name: account?.name ?? '',


### PR DESCRIPTION
## Summary
- fix AccountForm React Hook Form generics to align zodResolver input/output types and satisfy TypeScript

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: fetch failed, could not download swc)


------
https://chatgpt.com/codex/tasks/task_e_689aed32709c8325be26d52ac7e0447b