### PR TITLE
fix: align form resolver types

### DIFF
--- a/components/transactions/transaction-form.tsx
+++ b/components/transactions/transaction-form.tsx
@@ -51,8 +51,8 @@ const formSchema = z.object({
   note: z.string().optional(),
 });
 
-export type TransactionFormValues = z.output<typeof formSchema>;
-type TransactionFormInputs = z.input<typeof formSchema>;
+// Use the inferred output type for consumers of the form
+export type TransactionFormValues = z.infer<typeof formSchema>;
 
 interface Props {
   open: boolean;
@@ -73,7 +73,10 @@ export function TransactionForm({
   onSubmit,
   onDelete,
 }: Props) {
-  const form = useForm<TransactionFormInputs, any, TransactionFormValues>({
+  // react-hook-form's resolver expects the schema's input type, while the
+  // submit handler uses the parsed output type. Specify both generics so the
+  // form works with Zod's coercion (e.g. `z.coerce.number()`).
+  const form = useForm<z.input<typeof formSchema>, any, TransactionFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       date: new Date(),


### PR DESCRIPTION
## Summary
- align react-hook-form generics with zod resolver outputs

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689af3058d288325ba072f3475bdb5f7