### PR TITLE
fix: type-safe amount field

### DIFF
--- a/components/transactions/transaction-form.tsx
+++ b/components/transactions/transaction-form.tsx
@@ -51,7 +51,8 @@ const formSchema = z.object({
   note: z.string().optional(),
 });
 
-export type TransactionFormValues = z.output<typeof formSchema>;
+// Use the inferred output type for consumers of the form
+export type TransactionFormValues = z.infer<typeof formSchema>;
 
 interface Props {
   open: boolean;
@@ -72,7 +73,10 @@ export function TransactionForm({
   onSubmit,
   onDelete,
 }: Props) {
-  const form = useForm<TransactionFormValues>({
+  // react-hook-form's resolver expects the schema's input type, while the
+  // submit handler uses the parsed output type. Specify both generics so the
+  // form works with Zod's coercion (e.g. `z.coerce.number()`).
+  const form = useForm<z.input<typeof formSchema>, any, TransactionFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       date: new Date(),


### PR DESCRIPTION
## Summary
- ensure amount input uses type-safe value

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: fetch failed, ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_689af5ed31848325a0e8d1a84749f0de