### PR TITLE
fix form resolver types

### DIFF
--- a/components/transactions/transaction-form.tsx
+++ b/components/transactions/transaction-form.tsx
@@ -51,7 +51,8 @@ const formSchema = z.object({
   note: z.string().optional(),
 });
 
-export type TransactionFormValues = z.output<typeof formSchema>;
+// Use the inferred output type for consumers of the form
+export type TransactionFormValues = z.infer<typeof formSchema>;
 
 interface Props {
   open: boolean;
@@ -72,7 +73,10 @@ export function TransactionForm({
   onSubmit,
   onDelete,
 }: Props) {
-  const form = useForm<TransactionFormValues>({
+  // react-hook-form's resolver expects the schema's input type, while the
+  // submit handler uses the parsed output type. Specify both generics so the
+  // form works with Zod's coercion (e.g. `z.coerce.number()`).
+  const form = useForm<z.input<typeof formSchema>, any, TransactionFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       date: new Date(),


### PR DESCRIPTION
## Summary
- use Zod's inferred types for transaction form
- align react-hook-form resolver generics with schema input and output types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: fetch failed: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689af88f7a54832583debf6bbc5771c1