### PR TITLE
fix: add generateStaticParams for budget detail route

### DIFF
--- a/app/(dashboard)/budgets/[id]/page.tsx
+++ b/app/(dashboard)/budgets/[id]/page.tsx
@@ -28,6 +28,10 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Progress } from "@/components/ui/progress";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
+export async function generateStaticParams() {
+  return [];
+}
+
 const toCamel = (str: string) => str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
 
 function keysToCamel<T>(obj: any): T {


### PR DESCRIPTION
## Summary
- add empty `generateStaticParams` to budgets dynamic page for Next.js static export

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: fetch failed while downloading SWC binary)*

------
https://chatgpt.com/codex/tasks/task_e_689b024323a48325a49dd431ac60c048