### PR TITLE
Fix static params for account edit route

### DIFF
--- a/app/(dashboard)/accounts/[id]/edit/page.tsx
+++ b/app/(dashboard)/accounts/[id]/edit/page.tsx
@@ -19,12 +19,6 @@ function keysToCamel<T>(obj: any): T {
   return obj as T;
 }
 
-export async function generateStaticParams() {
-  const supabase = createServerClient();
-  const { data } = await supabase.from('accounts').select('id');
-  return data?.map(({ id }) => ({ id })) ?? [];
-}
-
 interface PageProps {
   params: { id: string };
 }

--- a/app/(dashboard)/accounts/[id]/layout.tsx
+++ b/app/(dashboard)/accounts/[id]/layout.tsx
@@ -1,0 +1,16 @@
+import { createServerClient } from '@/lib/supabase';
+
+export async function generateStaticParams() {
+  const supabase = createServerClient();
+  const { data } = await supabase.from('accounts').select('id');
+  return data?.map(({ id }) => ({ id })) ?? [];
+}
+
+export default function AccountLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}
+


### PR DESCRIPTION
## Summary
- add layout to generate static account IDs for export builds
- simplify account edit page to focus on data fetch and rendering

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed downloading swc package)*

------
https://chatgpt.com/codex/tasks/task_e_689b0ffdffc88325b12df14b75808f14