### PR TITLE
feat: add budget creation modal

### DIFF
--- a/app/(dashboard)/budgets/page.tsx
+++ b/app/(dashboard)/budgets/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { Plus } from "lucide-react";
 import { format } from "date-fns";
 
@@ -21,6 +20,7 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { BudgetDetailDialog } from "@/components/budgets/budget-detail-dialog";
+import { BudgetFormDialog } from "@/components/budgets/budget-form-dialog";
 
 const toCamel = (str: string) => str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
 
@@ -53,6 +53,7 @@ export default function BudgetsPage() {
   const [year, setYear] = useState("all");
   const [month, setMonth] = useState("all");
   const [selectedBudgetId, setSelectedBudgetId] = useState<string | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
 
   useEffect(() => {
     if (!user) return;
@@ -164,11 +165,12 @@ export default function BudgetsPage() {
           <p className="text-muted-foreground">Manage your budgets.</p>
         </div>
         <div className="hidden md:block">
-          <Link href="/budgets/new">
-            <Button className="transition-transform hover:scale-105">
-              Add Budget
-            </Button>
-          </Link>
+          <Button
+            onClick={() => setIsAdding(true)}
+            className="transition-transform hover:scale-105"
+          >
+            Add Budget
+          </Button>
         </div>
       </div>
 
@@ -214,16 +216,12 @@ export default function BudgetsPage() {
         {filteredBudgets.map((b) => renderBudgetCard(b))}
       </div>
 
-      <Link
-        href="/budgets/new"
-        className="md:hidden fixed bottom-6 right-6"
+      <Button
+        onClick={() => setIsAdding(true)}
+        className="md:hidden fixed bottom-6 right-6 h-12 w-12 rounded-full p-0 shadow-lg transition-transform hover:scale-105"
       >
-        <Button
-          className="h-12 w-12 rounded-full p-0 shadow-lg transition-transform hover:scale-105"
-        >
-          <Plus className="h-6 w-6" />
-        </Button>
-      </Link>
+        <Plus className="h-6 w-6" />
+      </Button>
       <BudgetDetailDialog
         budgetId={selectedBudgetId}
         open={selectedBudgetId !== null}
@@ -231,6 +229,7 @@ export default function BudgetsPage() {
           if (!open) setSelectedBudgetId(null);
         }}
       />
+      <BudgetFormDialog open={isAdding} onOpenChange={setIsAdding} />
     </div>
   );
 }

--- a/app/api/budgets/route.ts
+++ b/app/api/budgets/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+
+export async function POST(req: Request) {
+  const { userId, month, items } = await req.json();
+  const supabase = createServerClient();
+
+  const { data: budget, error } = await supabase
+    .from('budgets')
+    .insert({ user_id: userId, month })
+    .select('id')
+    .single();
+
+  if (error || !budget) {
+    return NextResponse.json({ error: error?.message || 'Insert failed' }, { status: 400 });
+  }
+
+  if (items && items.length) {
+    const { error: itemsError } = await supabase.from('budget_items').insert(
+      items.map((i: any) => ({
+        budget_id: budget.id,
+        category_id: i.categoryId,
+        amount: i.amount,
+        rollover: i.rollover ?? false,
+      }))
+    );
+    if (itemsError) {
+      return NextResponse.json({ error: itemsError.message }, { status: 400 });
+    }
+  }
+
+  const { data: fullBudget, error: fetchError } = await supabase
+    .from('budgets')
+    .select('*, items:budget_items(*, category:categories(*))')
+    .eq('id', budget.id)
+    .single();
+
+  if (fetchError || !fullBudget) {
+    return NextResponse.json({ error: fetchError?.message || 'Fetch failed' }, { status: 400 });
+  }
+
+  return NextResponse.json(fullBudget);
+}

--- a/components/budgets/budget-form-dialog.tsx
+++ b/components/budgets/budget-form-dialog.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAppStore } from '@/lib/store';
+import { supabase } from '@/lib/supabase';
+import { Budget, Category } from '@/types';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+
+const toCamel = (str: string) => str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+
+function keysToCamel<T>(obj: any): T {
+  if (Array.isArray(obj)) {
+    return obj.map((v) => keysToCamel(v)) as any;
+  }
+  if (obj && typeof obj === 'object' && obj.constructor === Object) {
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[toCamel(key)] = keysToCamel(value);
+    }
+    return result as T;
+  }
+  return obj as T;
+}
+
+type ItemInput = { categoryId: string; amount: string };
+
+type BudgetFormDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function BudgetFormDialog({ open, onOpenChange }: BudgetFormDialogProps) {
+  const { user, categories, setCategories, budgets, setBudgets } = useAppStore();
+  const [month, setMonth] = useState<string>(() => new Date().toISOString().slice(0, 7));
+  const [items, setItems] = useState<ItemInput[]>([{ categoryId: '', amount: '' }]);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open || categories.length || !user) return;
+    const fetchCategories = async () => {
+      const { data } = await supabase
+        .from('categories')
+        .select('*')
+        .eq('user_id', user.id)
+        .eq('type', 'expense');
+      if (data) setCategories(keysToCamel<Category[]>(data));
+    };
+    fetchCategories();
+  }, [open, categories.length, user, setCategories]);
+
+  const handleItemChange = (index: number, field: keyof ItemInput, value: string) => {
+    const updated = [...items];
+    updated[index] = { ...updated[index], [field]: value };
+    setItems(updated);
+  };
+
+  const addItem = () => setItems([...items, { categoryId: '', amount: '' }]);
+
+  const handleSubmit = async () => {
+    if (!user) return;
+    setSubmitting(true);
+    const payload = {
+      userId: user.id,
+      month,
+      items: items
+        .filter((i) => i.categoryId && i.amount)
+        .map((i) => ({
+          categoryId: i.categoryId,
+          amount: Number(i.amount),
+          rollover: false,
+        })),
+    };
+    const res = await fetch('/api/budgets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const newBudget = keysToCamel<Budget>(data);
+      setBudgets([...budgets, newBudget]);
+      onOpenChange(false);
+      setMonth(new Date().toISOString().slice(0, 7));
+      setItems([{ categoryId: '', amount: '' }]);
+    }
+    setSubmitting(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Budget</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Month</label>
+            <Input type="month" value={month} onChange={(e) => setMonth(e.target.value)} />
+          </div>
+          {items.map((item, idx) => (
+            <div key={idx} className="flex gap-2">
+              <Select
+                value={item.categoryId}
+                onValueChange={(v) => handleItemChange(idx, 'categoryId', v)}
+              >
+                <SelectTrigger className="w-1/2">
+                  <SelectValue placeholder="Category" />
+                </SelectTrigger>
+                <SelectContent>
+                  {categories
+                    .filter((c) => c.type === 'expense')
+                    .map((c) => (
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+              <Input
+                type="number"
+                placeholder="Amount"
+                value={item.amount}
+                onChange={(e) => handleItemChange(idx, 'amount', e.target.value)}
+              />
+            </div>
+          ))}
+          <Button type="button" variant="secondary" onClick={addItem}>
+            Add Item
+          </Button>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add budget creation dialog with month and item inputs
- replace budget page link with modal trigger
- implement /api/budgets POST endpoint to save budgets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689b2f90646c83259475f3719753c923