### PR TITLE
feat: add REST APIs for core features

### DIFF
--- a/app/api/accounts/[id]/route.ts
+++ b/app/api/accounts/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const { name, type, currency, openingBalance, archived } = await req.json();
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('accounts')
+    .update({
+      name,
+      type,
+      currency,
+      opening_balance: openingBalance,
+      archived,
+    })
+    .eq('id', params.id)
+    .select('*')
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const supabase = createServerClient();
+  const { error } = await supabase.from('accounts').delete().eq('id', params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId');
+  if (!userId) {
+    return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+  }
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('accounts')
+    .select('*')
+    .eq('user_id', userId);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request) {
+  const { userId, name, type, currency, openingBalance, archived } = await req.json();
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('accounts')
+    .insert({
+      user_id: userId,
+      name,
+      type,
+      currency,
+      opening_balance: openingBalance,
+      archived: archived ?? false,
+    })
+    .select('*')
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}

--- a/app/api/budgets/route.ts
+++ b/app/api/budgets/route.ts
@@ -1,6 +1,23 @@
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId');
+  if (!userId) {
+    return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+  }
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('budgets')
+    .select('*, items:budget_items(*, category:categories(*))')
+    .eq('user_id', userId);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}
+
 export async function POST(req: Request) {
   const { userId, month, items } = await req.json();
   const supabase = createServerClient();

--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const { name, type, color, icon } = await req.json();
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('categories')
+    .update({ name, type, color, icon })
+    .eq('id', params.id)
+    .select('*')
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const supabase = createServerClient();
+  const { error } = await supabase.from('categories').delete().eq('id', params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId');
+  if (!userId) {
+    return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+  }
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('categories')
+    .select('*')
+    .eq('user_id', userId);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request) {
+  const { userId, name, type, color, icon } = await req.json();
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('categories')
+    .insert({
+      user_id: userId,
+      name,
+      type,
+      color,
+      icon,
+    })
+    .select('*')
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const { date, type, accountId, fromAccountId, toAccountId, amount, categoryId, note, tags } = await req.json();
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('transactions')
+    .update({
+      date,
+      type,
+      account_id: accountId,
+      from_account_id: fromAccountId,
+      to_account_id: toAccountId,
+      amount,
+      category_id: categoryId,
+      note,
+      tags,
+    })
+    .eq('id', params.id)
+    .select(
+      `*,
+      account:accounts(name, type),
+      from_account:accounts!transactions_from_account_id_fkey(name, type),
+      to_account:accounts!transactions_to_account_id_fkey(name, type),
+      category:categories(name, color, icon)`
+    )
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const supabase = createServerClient();
+  const { error } = await supabase.from('transactions').delete().eq('id', params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId');
+  if (!userId) {
+    return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+  }
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('transactions')
+    .select(
+      `*,
+      account:accounts(name, type),
+      from_account:accounts!transactions_from_account_id_fkey(name, type),
+      to_account:accounts!transactions_to_account_id_fkey(name, type),
+      category:categories(name, color, icon)`
+    )
+    .eq('user_id', userId);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request) {
+  const { userId, date, type, accountId, fromAccountId, toAccountId, amount, categoryId, note, tags } = await req.json();
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('transactions')
+    .insert({
+      user_id: userId,
+      date,
+      type,
+      account_id: accountId,
+      from_account_id: fromAccountId,
+      to_account_id: toAccountId,
+      amount,
+      category_id: categoryId,
+      note,
+      tags,
+    })
+    .select(
+      `*,
+      account:accounts(name, type),
+      from_account:accounts!transactions_from_account_id_fkey(name, type),
+      to_account:accounts!transactions_to_account_id_fkey(name, type),
+      category:categories(name, color, icon)`
+    )
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}


### PR DESCRIPTION
## Summary
- create account API endpoints for listing, creating, updating, and deleting accounts
- add category API endpoints for CRUD operations
- implement transaction API for managing transaction records
- expose budget retrieval API alongside creation endpoint

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b320649888325894954cefa6d1813