### PR TITLE
Add supabase index and example environment file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Supabase Configuration
+
+NEXT_PUBLIC_SUPABASE_URL=https://vndzpnjbbkkejgghpbgm.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZuZHpwbmpiYmtrZWpnZ2hwYmdtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ4MzQxNjMsImV4cCI6MjA3MDQxMDE2M30.qv2w4Tc-wCx75OpWTWp5EeLBw2IGkc6Wrg3UCYfbER0
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+
+# Optional: Development settings
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-.env

--- a/lib/supabase/index.ts
+++ b/lib/supabase/index.ts
@@ -1,0 +1,2 @@
+export { supabase } from './client';
+export { createServerClient } from './server';


### PR DESCRIPTION
## Summary
- re-export Supabase helpers through a new `lib/supabase/index.ts`
- version `.env` based on `.env.example` for default Supabase config

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: fetch failed; ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_689cc176b0a483259b578b4354831de7