### PR TITLE
test: add Playwright auth flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,10 @@
         "vaul": "^0.9.9",
         "zod": "^4.0.17",
         "zustand": "^5.0.7"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.44.0",
+        "dotenv": "^16.3.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -507,6 +511,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3473,6 +3493,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5673,6 +5706,53 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "node scripts/seed-user.mjs"
+    "seed": "node scripts/seed-user.mjs",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
@@ -71,5 +72,9 @@
     "vaul": "^0.9.9",
     "zod": "^4.0.17",
     "zustand": "^5.0.7"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.44.0",
+    "dotenv": "^16.3.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+import { config as dotenv } from 'dotenv';
+dotenv();
+
+const PORT = process.env.PORT || 3000;
+const SITE_URL = process.env.SITE_URL || `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  reporter: [['html', { open: 'never' }]],
+  use: {
+    baseURL: SITE_URL,
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: SITE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,21 @@
+# E2E Tests
+
+Playwright tests cover Supabase email/password authentication flows.
+
+## Environment Variables
+Set the following variables before running tests:
+
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SITE_URL` – URL where the Next.js app is running (default `http://localhost:3000`).
+
+## Running
+Install dependencies and run:
+
+```bash
+npm install
+npm run test:e2e
+```
+
+Reports are available under `playwright-report` after execution.

--- a/tests/auth/email-verification.spec.ts
+++ b/tests/auth/email-verification.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '../fixtures';
+import { genEmail } from '../utils/genEmail';
+import { confirmEmail } from '../utils/mail';
+
+// Simulated email verification using Admin API
+ test('email can be verified via admin', async ({ supabaseAdmin }) => {
+  const email = genEmail();
+  const password = 'Password123';
+
+  const { data: created } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: false,
+  });
+  const userId = created.user!.id;
+
+  // initially not confirmed
+  const { data: before } = await supabaseAdmin.auth.admin.getUserById(userId);
+  expect(before.user?.email_confirmed_at).toBeNull();
+
+  await confirmEmail(userId);
+
+  const { data: after } = await supabaseAdmin.auth.admin.getUserById(userId);
+  expect(after.user?.email_confirmed_at).not.toBeNull();
+
+  await supabaseAdmin.from('profiles').delete().eq('id', userId);
+  await supabaseAdmin.auth.admin.deleteUser(userId);
+ });

--- a/tests/auth/forgot-reset.spec.ts
+++ b/tests/auth/forgot-reset.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '../fixtures';
+import { genEmail } from '../utils/genEmail';
+import { loginUI } from '../utils/helpers';
+
+ test('forgot and reset password flow', async ({ page, supabaseAdmin }) => {
+  const email = genEmail();
+  const password = 'Password123';
+  await supabaseAdmin.auth.admin.createUser({ email, password, email_confirm: true });
+
+  await page.goto('/auth/forgot');
+  await page.getByLabel('Email').fill(email);
+  await page.getByRole('button', { name: /send reset link/i }).click();
+  await expect(page.getByText(/if the email exists/i)).toBeVisible();
+
+  const { data: linkData } = await supabaseAdmin.auth.admin.generateLink({ type: 'recovery', email });
+  const { action_link } = linkData.properties!;
+
+  await page.goto(action_link!);
+  await page.getByLabel('New Password').fill('NewPassword123');
+  await page.getByLabel('Confirm Password').fill('NewPassword123');
+  await page.getByRole('button', { name: /reset password/i }).click();
+  await expect(page).toHaveURL(/auth\/signin/);
+
+  await loginUI(page, email, 'NewPassword123');
+
+  const { data } = await supabaseAdmin.auth.admin.getUserByEmail(email);
+  if (data.user) {
+    await supabaseAdmin.from('profiles').delete().eq('id', data.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(data.user.id);
+  }
+ });

--- a/tests/auth/route-protection.spec.ts
+++ b/tests/auth/route-protection.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '../fixtures';
+import { genEmail } from '../utils/genEmail';
+import { loginUI } from '../utils/helpers';
+
+ test.describe('route protection', () => {
+  test('redirects unauthenticated user', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page).toHaveURL(/auth\/signin/);
+  });
+
+  test('allows authenticated user', async ({ page, supabaseAdmin }) => {
+    const email = genEmail();
+    const password = 'Password123';
+    const { data: created } = await supabaseAdmin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
+    const userId = created.user!.id;
+
+    await loginUI(page, email, password);
+    await page.goto('/settings');
+    await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible();
+
+    await supabaseAdmin.from('profiles').delete().eq('id', userId);
+    await supabaseAdmin.auth.admin.deleteUser(userId);
+  });
+ });

--- a/tests/auth/sign-in.happy.spec.ts
+++ b/tests/auth/sign-in.happy.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '../fixtures';
+import { genEmail } from '../utils/genEmail';
+import { loginUI } from '../utils/helpers';
+
+ test('user can sign in', async ({ page, supabaseAdmin }) => {
+  const email = genEmail();
+  const password = 'Password123';
+  const { data: created } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  const userId = created.user!.id;
+
+  await loginUI(page, email, password);
+  await expect(page.getByRole('heading', { name: /dashboard/i })).toBeVisible();
+
+  // visiting sign-in when logged in should redirect
+  await page.goto('/auth/signin');
+  await expect(page).toHaveURL(/dashboard/);
+
+  await supabaseAdmin.from('profiles').delete().eq('id', userId);
+  await supabaseAdmin.auth.admin.deleteUser(userId);
+});

--- a/tests/auth/sign-in.negative.spec.ts
+++ b/tests/auth/sign-in.negative.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '../fixtures';
+import { genEmail } from '../utils/genEmail';
+
+ test.describe('sign in negatives', () => {
+  test('wrong password', async ({ page, supabaseAdmin }) => {
+    const email = genEmail();
+    await supabaseAdmin.auth.admin.createUser({ email, password: 'Password123', email_confirm: true });
+
+    await page.goto('/auth/signin');
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill('WrongPass123');
+    await page.getByRole('button', { name: /sign in/i }).click();
+    await expect(page.getByText(/invalid login credentials/i)).toBeVisible();
+  });
+
+  test('non existent email', async ({ page }) => {
+    await page.goto('/auth/signin');
+    await page.getByLabel('Email').fill(genEmail());
+    await page.getByLabel('Password').fill('Password123');
+    await page.getByRole('button', { name: /sign in/i }).click();
+    await expect(page.getByText(/invalid login credentials/i)).toBeVisible();
+  });
+});

--- a/tests/auth/sign-up.happy.spec.ts
+++ b/tests/auth/sign-up.happy.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '../fixtures';
+import { genEmail } from '../utils/genEmail';
+
+// Sign-up happy path
+ test('user can sign up', async ({ page, supabaseAdmin }) => {
+  const email = genEmail();
+  const password = 'Password123';
+
+  await page.goto('/auth/signup');
+  await page.getByLabel('Full Name').fill('Test User');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByLabel('Confirm Password').fill(password);
+  await page.getByRole('button', { name: /create account/i }).click();
+
+  // Expect redirect to sign in page after success
+  await expect(page).toHaveURL(/auth\/signin/);
+
+  // Verify user exists in Supabase
+  const { data: user } = await supabaseAdmin.auth.admin.getUserByEmail(email);
+  expect(user?.user?.email).toBe(email);
+  const userId = user?.user?.id as string;
+
+  const { data: profile } = await supabaseAdmin.from('profiles').select('*').eq('id', userId).single();
+  expect(profile).toBeTruthy();
+
+  // Cleanup
+  await supabaseAdmin.from('profiles').delete().eq('id', userId);
+  await supabaseAdmin.auth.admin.deleteUser(userId);
+});

--- a/tests/auth/sign-up.validation.spec.ts
+++ b/tests/auth/sign-up.validation.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '../fixtures';
+import { genEmail } from '../utils/genEmail';
+
+test.describe('sign up validation', () => {
+  test('shows errors on empty submit', async ({ page }) => {
+    await page.goto('/auth/signup');
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page.getByText('Name must be at least')).toBeVisible();
+    await expect(page.getByText('Invalid email')).toBeVisible();
+    await expect(page.getByText('Password must be at least')).toBeVisible();
+  });
+
+  test('invalid email', async ({ page }) => {
+    await page.goto('/auth/signup');
+    await page.getByLabel('Full Name').fill('Test User');
+    await page.getByLabel('Email').fill('not-an-email');
+    await page.getByLabel('Password').fill('Password123');
+    await page.getByLabel('Confirm Password').fill('Password123');
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page.getByText('Invalid email address')).toBeVisible();
+  });
+
+  test('password too short', async ({ page }) => {
+    await page.goto('/auth/signup');
+    await page.getByLabel('Full Name').fill('Test User');
+    await page.getByLabel('Email').fill(genEmail());
+    await page.getByLabel('Password').fill('short');
+    await page.getByLabel('Confirm Password').fill('short');
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page.getByText('Password must be at least')).toBeVisible();
+  });
+
+  test('mismatched passwords', async ({ page }) => {
+    await page.goto('/auth/signup');
+    await page.getByLabel('Full Name').fill('Test User');
+    await page.getByLabel('Email').fill(genEmail());
+    await page.getByLabel('Password').fill('Password123');
+    await page.getByLabel('Confirm Password').fill('Password124');
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page.getByText("Passwords don't match")).toBeVisible();
+  });
+
+  test('existing email', async ({ page, supabaseAdmin }) => {
+    const email = genEmail();
+    const password = 'Password123';
+    await supabaseAdmin.auth.admin.createUser({ email, password, email_confirm: true });
+
+    await page.goto('/auth/signup');
+    await page.getByLabel('Full Name').fill('Test User');
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByLabel('Confirm Password').fill(password);
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page.getByText(/already registered/i)).toBeVisible();
+
+    const { data } = await supabaseAdmin.auth.admin.getUserByEmail(email);
+    if (data.user) {
+      await supabaseAdmin.from('profiles').delete().eq('id', data.user.id);
+      await supabaseAdmin.auth.admin.deleteUser(data.user.id);
+    }
+  });
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,14 @@
+import { test as base } from '@playwright/test';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { env } from './utils/env';
+
+export const test = base.extend<{ supabaseAdmin: SupabaseClient }>({
+  supabaseAdmin: async ({}, use) => {
+    const client = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+      auth: { persistSession: false },
+    });
+    await use(client);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/utils/env.ts
+++ b/tests/utils/env.ts
@@ -1,0 +1,17 @@
+import { config } from 'dotenv';
+config();
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+  return value;
+}
+
+export const env = {
+  SUPABASE_URL: requireEnv('SUPABASE_URL'),
+  SUPABASE_ANON_KEY: requireEnv('SUPABASE_ANON_KEY'),
+  SUPABASE_SERVICE_ROLE_KEY: requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
+  SITE_URL: process.env.SITE_URL || 'http://localhost:3000',
+};

--- a/tests/utils/genEmail.ts
+++ b/tests/utils/genEmail.ts
@@ -1,0 +1,4 @@
+export function genEmail() {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `test-${unique}@example.com`;
+}

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -1,0 +1,14 @@
+import { expect, Page } from '@playwright/test';
+
+export async function loginUI(page: Page, email: string, password: string) {
+  await page.goto('/auth/signin');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await expect(page).toHaveURL(/dashboard/);
+}
+
+export async function logoutUI(page: Page) {
+  await page.getByRole('button', { name: /sign out/i }).click();
+  await expect(page).toHaveURL(/auth\/signin/);
+}

--- a/tests/utils/mail.ts
+++ b/tests/utils/mail.ts
@@ -1,0 +1,8 @@
+import { supabaseAdmin } from './supabaseAdmin';
+
+/**
+ * Mark a user's email as confirmed via Supabase Admin API.
+ */
+export async function confirmEmail(userId: string) {
+  await supabaseAdmin.auth.admin.updateUserById(userId, { email_confirm: true });
+}

--- a/tests/utils/supabaseAdmin.ts
+++ b/tests/utils/supabaseAdmin.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+import { env } from './env';
+
+export const supabaseAdmin = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["@types/node", "@playwright/test"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- add Playwright setup and auth E2E tests
- verify Supabase auth flows via admin API
- document required env vars for running tests

## Testing
- `npx playwright install --with-deps` *(fails: Error: Download failed: server returned code 403)*
- `SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service SITE_URL=http://localhost:3000 npx playwright test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689cc8d9433c8325b6e736f3c8c1d2b2