### PR TITLE
Add constraints for transaction account fields

### DIFF
--- a/supabase/migrations/20240218160000_add_transaction_type_constraints.sql
+++ b/supabase/migrations/20240218160000_add_transaction_type_constraints.sql
@@ -1,0 +1,14 @@
+-- Add check constraints for transaction type account requirements
+alter table public.transactions
+  add constraint transactions_expense_income_accounts_check
+  check (
+    type not in ('expense', 'income') or
+    (account_id is not null and from_account_id is null and to_account_id is null)
+  );
+
+alter table public.transactions
+  add constraint transactions_transfer_accounts_check
+  check (
+    type <> 'transfer' or
+    (account_id is null and from_account_id is not null and to_account_id is not null)
+  );


### PR DESCRIPTION
## Summary
- ensure expense/income transactions use account_id and no from/to accounts
- ensure transfer transactions use from/to accounts and no account_id

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d5dd04b108325a8ae0d65eaaef5f3