### PR TITLE
Add unique constraint on budgets for user, month, and account

### DIFF
--- a/supabase/migrations/20240218160000_add_budget_unique_constraint.sql
+++ b/supabase/migrations/20240218160000_add_budget_unique_constraint.sql
@@ -1,0 +1,7 @@
+-- Ensure each user has at most one budget per account per month
+alter table public.budgets
+  drop constraint if exists budgets_user_month_account_unique,
+  add constraint budgets_user_month_account_unique unique (user_id, month, account_id);
+
+-- Reload PostgREST schema cache to pick up the new constraint
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- ensure budgets have unique user/month/account combinations

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run test:e2e` (fails: fetch failed ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_689d5dd25a10832596c02d09d43ddac8