### PR TITLE
feat: add debt management with share links

### DIFF
--- a/app/(dashboard)/debts/page.tsx
+++ b/app/(dashboard)/debts/page.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAppStore } from '@/lib/store';
+import { Debt } from '@/types';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+export default function DebtsPage() {
+  const { user, debts, setDebts, loading, setLoading } = useAppStore();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [form, setForm] = useState({ contact: '', amount: '', note: '', type: 'debt' });
+
+  useEffect(() => {
+    if (!user) return;
+    const fetchDebts = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch('/api/debts');
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Failed');
+        setDebts(data);
+      } catch (e) {
+        toast.error('Failed to fetch debts');
+      }
+      setLoading(false);
+    };
+    fetchDebts();
+  }, [user, setDebts, setLoading]);
+
+  const handleSubmit = async () => {
+    const payload = {
+      contact: form.contact,
+      amount: Number(form.amount),
+      note: form.note,
+      type: form.type as 'debt' | 'credit',
+    };
+    const res = await fetch('/api/debts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setDebts([...debts, data]);
+      toast.success('Debt added');
+      setDialogOpen(false);
+      setForm({ contact: '', amount: '', note: '', type: 'debt' });
+    } else {
+      toast.error(data.error || 'Failed to save debt');
+    }
+  };
+
+  const share = (id: string) => {
+    const url = `${window.location.origin}/debt/${id}`;
+    navigator.clipboard.writeText(url);
+    toast.success('Link copied');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Debts</h1>
+        <Button onClick={() => setDialogOpen(true)}>Add</Button>
+      </div>
+      <div className="space-y-2">
+        {debts.map((d: Debt) => (
+          <div key={d.id} className="border rounded p-3 flex justify-between items-center">
+            <div>
+              <div className="font-medium">{d.contact}</div>
+              <div className="text-sm text-muted-foreground">
+                {d.type === 'debt' ? 'You owe' : 'Owed to you'} {d.amount}
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => share(d.id)}>
+              Share
+            </Button>
+          </div>
+        ))}
+        {!loading && debts.length === 0 && (
+          <p className="text-sm text-muted-foreground">No debts recorded.</p>
+        )}
+      </div>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Debt</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              placeholder="Name"
+              value={form.contact}
+              onChange={(e) => setForm({ ...form, contact: e.target.value })}
+            />
+            <Input
+              type="number"
+              placeholder="Amount"
+              value={form.amount}
+              onChange={(e) => setForm({ ...form, amount: e.target.value })}
+            />
+            <Input
+              placeholder="Note"
+              value={form.note}
+              onChange={(e) => setForm({ ...form, note: e.target.value })}
+            />
+            <Select
+              value={form.type}
+              onValueChange={(v) => setForm({ ...form, type: v })}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="debt">Hutang</SelectItem>
+                <SelectItem value="credit">Piutang</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="pt-4">
+            <Button onClick={handleSubmit} className="w-full">
+              Save
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/api/debts/[id]/route.ts
+++ b/app/api/debts/[id]/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase/server';
+import { getUser } from '@/lib/auth/server';
+import { debtSchema } from '@/lib/validation';
+import { z } from 'zod';
 
 export async function GET(
   _req: Request,
@@ -26,4 +29,55 @@ export async function GET(
     shareId: data.share_id,
     attachments: data.attachments,
   });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createServerClient();
+  let body: z.infer<typeof debtSchema>;
+  try {
+    body = debtSchema.partial().parse(await req.json());
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+  try {
+    const user = await getUser();
+    const { data, error } = await supabase
+      .from('debts')
+      .update({
+        contact: body.contact,
+        amount: body.amount,
+        note: body.note,
+        type: body.type,
+        status: body.status,
+        due_date: body.dueDate ?? null,
+        attachments: body.attachments,
+      })
+      .eq('id', params.id)
+      .eq('user_id', user.id)
+      .select('*')
+      .single();
+    if (error || !data) {
+      return NextResponse.json(
+        { error: error?.message || 'Failed to update debt' },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({
+      id: data.id,
+      userId: data.user_id,
+      contact: data.contact,
+      amount: data.amount,
+      note: data.note,
+      type: data.type,
+      status: data.status,
+      dueDate: data.due_date,
+      shareId: data.share_id,
+      attachments: data.attachments,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 401 });
+  }
 }

--- a/app/api/debts/[id]/route.ts
+++ b/app/api/debts/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from('debts')
+    .select('*')
+    .eq('id', params.id)
+    .single();
+  if (error || !data) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json({
+    id: data.id,
+    userId: data.user_id,
+    contact: data.contact,
+    amount: data.amount,
+    note: data.note,
+    type: data.type,
+    status: data.status,
+    dueDate: data.due_date,
+  });
+}

--- a/app/api/debts/[id]/route.ts
+++ b/app/api/debts/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
   const { data, error } = await supabase
     .from('debts')
     .select('*')
-    .eq('id', params.id)
+    .eq('share_id', params.id)
     .single();
   if (error || !data) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
@@ -23,5 +23,7 @@ export async function GET(
     type: data.type,
     status: data.status,
     dueDate: data.due_date,
+    shareId: data.share_id,
+    attachments: data.attachments,
   });
 }

--- a/app/api/debts/[id]/route.ts
+++ b/app/api/debts/[id]/route.ts
@@ -36,7 +36,7 @@ export async function PATCH(
   { params }: { params: { id: string } }
 ) {
   const supabase = createServerClient();
-  let body: z.infer<typeof debtSchema>;
+  let body: Partial<z.infer<typeof debtSchema>>;
   try {
     body = debtSchema.partial().parse(await req.json());
   } catch (e) {

--- a/app/api/debts/route.ts
+++ b/app/api/debts/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
+import { getUser } from '@/lib/auth/server';
+import { debtSchema } from '@/lib/validation';
+import { z } from 'zod';
+
+export async function GET() {
+  const supabase = createServerClient();
+  try {
+    const user = await getUser();
+    const { data, error } = await supabase
+      .from('debts')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    const rows = (data ?? []).map((d) => ({
+      id: d.id,
+      userId: d.user_id,
+      contact: d.contact,
+      amount: d.amount,
+      note: d.note,
+      type: d.type,
+      status: d.status,
+      dueDate: d.due_date,
+    }));
+    return NextResponse.json(rows);
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 401 });
+  }
+}
+
+export async function POST(req: Request) {
+  const supabase = createServerClient();
+  let body: z.infer<typeof debtSchema>;
+  try {
+    body = debtSchema.parse(await req.json());
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+  }
+  try {
+    const user = await getUser();
+    const { data, error } = await supabase
+      .from('debts')
+      .insert({
+        user_id: user.id,
+        contact: body.contact,
+        amount: body.amount,
+        note: body.note,
+        type: body.type,
+        status: body.status,
+        due_date: body.dueDate ?? null,
+      })
+      .select('*')
+      .single();
+    if (error || !data) {
+      return NextResponse.json(
+        { error: error?.message || 'Failed to create debt' },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({
+      id: data.id,
+      userId: data.user_id,
+      contact: data.contact,
+      amount: data.amount,
+      note: data.note,
+      type: data.type,
+      status: data.status,
+      dueDate: data.due_date,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 401 });
+  }
+}

--- a/app/api/debts/route.ts
+++ b/app/api/debts/route.ts
@@ -25,6 +25,8 @@ export async function GET() {
       type: d.type,
       status: d.status,
       dueDate: d.due_date,
+      shareId: d.share_id,
+      attachments: d.attachments,
     }));
     return NextResponse.json(rows);
   } catch (e) {
@@ -52,6 +54,7 @@ export async function POST(req: Request) {
         type: body.type,
         status: body.status,
         due_date: body.dueDate ?? null,
+        attachments: body.attachments ?? [],
       })
       .select('*')
       .single();
@@ -70,6 +73,8 @@ export async function POST(req: Request) {
       type: data.type,
       status: data.status,
       dueDate: data.due_date,
+      shareId: data.share_id,
+      attachments: data.attachments,
     });
   } catch (e) {
     return NextResponse.json({ error: (e as Error).message }, { status: 401 });

--- a/app/debt/[id]/page.tsx
+++ b/app/debt/[id]/page.tsx
@@ -1,0 +1,23 @@
+import { createServerClient } from '@/lib/supabase/server';
+import { notFound } from 'next/navigation';
+
+export default async function DebtSharePage({ params }: { params: { id: string } }) {
+  const supabase = createServerClient();
+  const { data } = await supabase
+    .from('debts')
+    .select('*')
+    .eq('id', params.id)
+    .single();
+  if (!data) {
+    notFound();
+  }
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold">Debt Detail</h1>
+      <p><strong>Name:</strong> {data.contact}</p>
+      <p><strong>Amount:</strong> {data.amount}</p>
+      {data.note && <p><strong>Note:</strong> {data.note}</p>}
+      <p><strong>Status:</strong> {data.status}</p>
+    </div>
+  );
+}

--- a/app/debt/[id]/page.tsx
+++ b/app/debt/[id]/page.tsx
@@ -6,7 +6,7 @@ export default async function DebtSharePage({ params }: { params: { id: string }
   const { data } = await supabase
     .from('debts')
     .select('*')
-    .eq('id', params.id)
+    .eq('share_id', params.id)
     .single();
   if (!data) {
     notFound();
@@ -18,6 +18,13 @@ export default async function DebtSharePage({ params }: { params: { id: string }
       <p><strong>Amount:</strong> {data.amount}</p>
       {data.note && <p><strong>Note:</strong> {data.note}</p>}
       <p><strong>Status:</strong> {data.status}</p>
+      {Array.isArray(data.attachments) && data.attachments.length > 0 && (
+        <div className="flex flex-wrap gap-2 pt-2">
+          {data.attachments.map((url: string) => (
+            <img key={url} src={url} alt="attachment" className="w-32 h-32 object-cover rounded" />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/debt/[id]/page.tsx
+++ b/app/debt/[id]/page.tsx
@@ -1,5 +1,11 @@
 import { createServerClient } from '@/lib/supabase/server';
 import { notFound } from 'next/navigation';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from '@/components/ui/card';
 
 export default async function DebtSharePage({ params }: { params: { id: string } }) {
   const supabase = createServerClient();
@@ -12,19 +18,46 @@ export default async function DebtSharePage({ params }: { params: { id: string }
     notFound();
   }
   return (
-    <div className="p-4 space-y-2">
-      <h1 className="text-2xl font-bold">Debt Detail</h1>
-      <p><strong>Name:</strong> {data.contact}</p>
-      <p><strong>Amount:</strong> {data.amount}</p>
-      {data.note && <p><strong>Note:</strong> {data.note}</p>}
-      <p><strong>Status:</strong> {data.status}</p>
-      {Array.isArray(data.attachments) && data.attachments.length > 0 && (
-        <div className="flex flex-wrap gap-2 pt-2">
-          {data.attachments.map((url: string) => (
-            <img key={url} src={url} alt="attachment" className="w-32 h-32 object-cover rounded" />
-          ))}
-        </div>
-      )}
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Debt Detail</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>
+            <strong>Name:</strong> {data.contact}
+          </p>
+          <p>
+            <strong>Amount:</strong> {data.amount}
+          </p>
+          {data.note && (
+            <p>
+              <strong>Note:</strong> {data.note}
+            </p>
+          )}
+          <p>
+            <strong>Status:</strong> {data.status}
+          </p>
+          {Array.isArray(data.attachments) && data.attachments.length > 0 && (
+            <div className="grid grid-cols-3 gap-2 pt-2">
+              {data.attachments.map((url: string) => (
+                <a
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src={url}
+                    alt="attachment"
+                    className="w-full h-32 object-cover rounded hover:opacity-90"
+                  />
+                </a>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -7,10 +7,11 @@ import { cn } from '@/lib/utils';
 import { 
   LayoutDashboard, 
   Wallet, 
-  Receipt, 
-  CreditCard, 
-  BarChart3, 
-  Settings, 
+  Receipt,
+  HandCoins,
+  CreditCard,
+  BarChart3,
+  Settings,
   Menu,
   X
 } from 'lucide-react';
@@ -20,6 +21,7 @@ const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
   { name: 'Budgets', href: '/budgets', icon: Wallet },
   { name: 'Transactions', href: '/transactions', icon: Receipt },
+  { name: 'Debts', href: '/debts', icon: HandCoins },
   { name: 'Accounts', href: '/accounts', icon: CreditCard },
   { name: 'Reports', href: '/reports', icon: BarChart3 },
   { name: 'Settings', href: '/settings', icon: Settings },

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { User, Account, Category, Transaction, Budget } from '@/types';
+import { User, Account, Category, Transaction, Budget, Debt } from '@/types';
 
 interface AppState {
   user: User | null;
@@ -7,6 +7,7 @@ interface AppState {
   categories: Category[];
   transactions: Transaction[];
   budgets: Budget[];
+  debts: Debt[];
   loading: boolean;
   
   // Actions
@@ -15,6 +16,7 @@ interface AppState {
   setCategories: (categories: Category[]) => void;
   setTransactions: (transactions: Transaction[]) => void;
   setBudgets: (budgets: Budget[]) => void;
+  setDebts: (debts: Debt[]) => void;
   setLoading: (loading: boolean) => void;
   
   // Computed
@@ -29,6 +31,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   categories: [],
   transactions: [],
   budgets: [],
+  debts: [],
   loading: false,
 
   setUser: (user) => set({ user }),
@@ -36,6 +39,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   setCategories: (categories) => set({ categories }),
   setTransactions: (transactions) => set({ transactions }),
   setBudgets: (budgets) => set({ budgets }),
+  setDebts: (debts) => set({ debts }),
   setLoading: (loading) => set({ loading }),
 
   getCurrentBalance: (accountId: string) => {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -52,6 +52,18 @@ export const budgetPatchSchema = z.object({
   items: z.array(budgetItemSchema).optional(),
 });
 
+export const debtSchema = z.object({
+  contact: z.string().min(1),
+  amount: z.number().positive(),
+  note: z.string().optional(),
+  type: z.enum(['debt', 'credit']),
+  status: z.enum(['unpaid', 'paid']).default('unpaid'),
+  dueDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
 const dateSchema = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/);

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -62,6 +62,7 @@ export const debtSchema = z.object({
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .optional(),
+  attachments: z.array(z.string().url()).optional(),
 });
 
 const dateSchema = z

--- a/supabase/migrations/20240815000000_add_debts_table.sql
+++ b/supabase/migrations/20240815000000_add_debts_table.sql
@@ -1,0 +1,20 @@
+-- Create debts table
+create table debts (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  contact text not null,
+  amount numeric not null,
+  note text,
+  type text not null check (type in ('debt','credit')),
+  status text not null default 'unpaid' check (status in ('unpaid','paid')),
+  due_date date,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+alter table debts enable row level security;
+create policy "Debts are accessible by owner" on debts
+  for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+create trigger update_debts_updated_at before update on debts
+  for each row execute procedure update_updated_at_column();
+create index debts_user_id_idx on debts(user_id);

--- a/supabase/migrations/20240915000000_extend_debts_with_public_and_attachments.sql
+++ b/supabase/migrations/20240915000000_extend_debts_with_public_and_attachments.sql
@@ -1,0 +1,3 @@
+alter table debts add column share_id uuid not null default gen_random_uuid() unique;
+alter table debts add column attachments text[] not null default '{}'::text[];
+create policy "Public read debts" on debts for select using (true);

--- a/supabase/migrations/20240916000000_create_debts_bucket.sql
+++ b/supabase/migrations/20240916000000_create_debts_bucket.sql
@@ -1,0 +1,14 @@
+insert into storage.buckets (id, name, public)
+values ('debts', 'debts', true)
+on conflict (id) do nothing;
+
+create policy "Public read access for debts" on storage.objects
+  for select using (bucket_id = 'debts');
+
+create policy "Authenticated users can upload debts" on storage.objects
+  for insert to authenticated
+  with check (bucket_id = 'debts');
+
+create policy "Users can delete own debts" on storage.objects
+  for delete to authenticated
+  using (bucket_id = 'debts' and auth.uid() = owner);

--- a/types/database.ts
+++ b/types/database.ts
@@ -196,6 +196,8 @@ export interface Database {
           type: 'debt' | 'credit';
           status: 'unpaid' | 'paid';
           due_date: string | null;
+          share_id: string;
+          attachments: string[];
           created_at: string;
           updated_at: string;
         };
@@ -208,6 +210,8 @@ export interface Database {
           type: 'debt' | 'credit';
           status?: 'unpaid' | 'paid';
           due_date?: string | null;
+          share_id?: string;
+          attachments?: string[];
           created_at?: string;
           updated_at?: string;
         };
@@ -218,6 +222,8 @@ export interface Database {
           type?: 'debt' | 'credit';
           status?: 'unpaid' | 'paid';
           due_date?: string | null;
+          share_id?: string;
+          attachments?: string[];
           updated_at?: string;
         };
       };

--- a/types/database.ts
+++ b/types/database.ts
@@ -186,6 +186,41 @@ export interface Database {
           updated_at?: string;
         };
       };
+      debts: {
+        Row: {
+          id: string;
+          user_id: string;
+          contact: string;
+          amount: number;
+          note: string;
+          type: 'debt' | 'credit';
+          status: 'unpaid' | 'paid';
+          due_date: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          contact: string;
+          amount: number;
+          note?: string;
+          type: 'debt' | 'credit';
+          status?: 'unpaid' | 'paid';
+          due_date?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          contact?: string;
+          amount?: number;
+          note?: string;
+          type?: 'debt' | 'credit';
+          status?: 'unpaid' | 'paid';
+          due_date?: string | null;
+          updated_at?: string;
+        };
+      };
     };
   };
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -90,6 +90,8 @@ export interface Debt {
   type: 'debt' | 'credit';
   status: 'unpaid' | 'paid';
   dueDate?: string;
+  shareId: string;
+  attachments: string[];
 }
 
 export type { CategoryPoint, ChartResponse } from './reports';

--- a/types/index.ts
+++ b/types/index.ts
@@ -81,4 +81,15 @@ export interface CategorySpend {
   color: string;
 }
 
+export interface Debt {
+  id: string;
+  userId: string;
+  contact: string;
+  amount: number;
+  note?: string;
+  type: 'debt' | 'credit';
+  status: 'unpaid' | 'paid';
+  dueDate?: string;
+}
+
 export type { CategoryPoint, ChartResponse } from './reports';


### PR DESCRIPTION
## Summary
- support tracking debts in store and types
- expose REST APIs for creating and fetching debts
- add dashboard debts page with shareable links and public detail view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3296ff7ac832590dec341b3f767c1