### PR TITLE
Ensure profile created on signup

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -47,23 +47,20 @@ export default function SignUpPage() {
   const onSubmit = async (data: SignUpForm) => {
     setLoading(true);
     try {
-      const response = await fetch('/api/auth/register', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-      });
+      const { ok, error } = await registerUser(
+        data.name,
+        data.email,
+        data.password,
+      );
 
-      const result = await response.json();
-      
-      if (!result.ok) {
-        throw new Error(result.error || 'Registration failed');
+      if (!ok) {
+        throw new Error(error || 'Registration failed');
       }
-      
+
       toast({
         title: 'Registration successful!',
-        description: "Please check your email to verify your account, then sign in.",
+        description:
+          "Please check your email to verify your account, then sign in.",
       });
 
       // Redirect to sign-in page after successful registration

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,18 +9,16 @@ export async function register(
   email: string,
   password: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  const { error } = await supabase.auth.signUp({
-    email,
-    password,
-    options: {
-      data: {
-        name,
-      },
-    },
+  const res = await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email, password }),
   });
 
-  if (error) {
-    return { ok: false, error: error.message };
+  const data = await res.json();
+
+  if (!data.ok) {
+    return { ok: false, error: data.error || 'Registration failed' };
   }
 
   return { ok: true };


### PR DESCRIPTION
## Summary
- route client signup through API to create user profile
- use shared register helper in signup page

## Testing
- `npm run lint`
- `npm run test:e2e tests/auth/sign-up.happy.spec.ts` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a726fe1edc83259df61dd595972266