### PR TITLE
style: refresh dashboard layout and add upgrade prompt

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -25,11 +25,11 @@ import {
   Wallet,
   TrendingUp,
   TrendingDown,
-  Calendar,
   DollarSign,
   Plus,
 } from 'lucide-react';
 import { formatDate } from '@/lib/date';
+import { useOffline } from '@/hooks/use-offline';
 
 const toCamel = (str: string) =>
   str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
@@ -64,33 +64,47 @@ export default function DashboardPage() {
   } = useAppStore();
   const [kpis, setKpis] = useState<DashboardKPIs>({
     totalBalance: 0,
-    monthlyBudget: 0,
-    monthlyActual: 0,
-    mtdSpend: 0,
-    dailyAverage: 0,
-    remainingAllowance: 0,
+    monthlyIncome: 0,
+    monthlyExpenses: 0,
+    savings: 0,
   });
   const [categorySpends, setCategorySpends] = useState<CategorySpend[]>([]);
   const [formOpen, setFormOpen] = useState(false);
+  const { isOnline, addOfflineChange } = useOffline();
 
   const handleSave = async (values: TransactionFormValues) => {
+    const payload = {
+      budgetMonth: values.budgetMonth,
+      actualDate: formatDate(values.actualDate),
+      date: formatDate(values.actualDate),
+      type: values.type,
+      accountId: values.accountId || undefined,
+      fromAccountId: values.fromAccountId || undefined,
+      toAccountId: values.toAccountId || undefined,
+      categoryId: values.categoryId || undefined,
+      amount: values.amount,
+      note: values.note || '',
+      tags: values.tags,
+    };
+
+    if (!isOnline) {
+      const tempTx: Transaction = {
+        id: `offline-${Date.now()}`,
+        userId: user?.id || '',
+        ...payload,
+      };
+      setTransactions([tempTx, ...transactions]);
+      await addOfflineChange('create', 'transactions', payload);
+      toast.success('Transaction saved offline');
+      setFormOpen(false);
+      return;
+    }
+
     try {
       const res = await fetch('/api/transactions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          budgetMonth: values.budgetMonth,
-          actualDate: formatDate(values.actualDate),
-          date: formatDate(values.actualDate),
-          type: values.type,
-          accountId: values.accountId,
-          fromAccountId: values.fromAccountId,
-          toAccountId: values.toAccountId,
-          categoryId: values.categoryId,
-          amount: values.amount,
-          note: values.note,
-          tags: values.tags,
-        }),
+        body: JSON.stringify(payload),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed to create transaction');
@@ -104,8 +118,8 @@ export default function DashboardPage() {
   };
 
   useEffect(() => {
-    if (!user) return;
-    
+    if (!user || !isOnline) return;
+
     const fetchData = async () => {
       setLoading(true);
       try {
@@ -115,17 +129,17 @@ export default function DashboardPage() {
           .select('*')
           .eq('user_id', user.id)
           .eq('archived', false);
-        
+
         // Fetch categories
         const { data: categoriesData } = await supabase
           .from('categories')
           .select('*')
           .eq('user_id', user.id);
-        
+
         // Fetch transactions (last 3 months)
         const threeMonthsAgo = new Date();
         threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
-        
+
         const { data: transactionsData } = await supabase
           .from('transactions')
           .select(`
@@ -162,15 +176,21 @@ export default function DashboardPage() {
     };
 
     fetchData();
-  }, [user, setAccounts, setTransactions, setBudgets, setCategories, setLoading]);
+  }, [
+    user,
+    isOnline,
+    setAccounts,
+    setTransactions,
+    setBudgets,
+    setCategories,
+    setLoading,
+  ]);
 
   useEffect(() => {
     if (!accounts.length || !transactions.length) return;
 
     // Calculate KPIs
     const currentMonth = new Date().toISOString().slice(0, 7);
-    const today = new Date().getDate();
-    const daysInMonth = new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0).getDate();
 
     // Total balance
     let totalBalance = 0;
@@ -200,28 +220,22 @@ export default function DashboardPage() {
 
     // Monthly budget and actual
     const currentBudgets = budgets.filter(b => b.month === currentMonth);
-    const monthlyBudget = currentBudgets.reduce((sum, b) => sum + b.totalAmount, 0);
-    
-    const monthlyActual = transactions
+
+    const monthlyIncome = transactions
+      .filter(t => t.type === 'income' && t.budgetMonth === currentMonth)
+      .reduce((sum, t) => sum + t.amount, 0);
+
+    const monthlyExpenses = transactions
       .filter(t => t.type === 'expense' && t.budgetMonth === currentMonth)
       .reduce((sum, t) => sum + t.amount, 0);
 
-    // MTD spend (same as monthly actual for current month)
-    const mtdSpend = monthlyActual;
-
-    // Daily average and remaining allowance
-    const dailyAverage = today > 0 ? mtdSpend / today : 0;
-    const remainingBudget = monthlyBudget - monthlyActual;
-    const remainingDays = daysInMonth - today;
-    const remainingAllowance = remainingDays > 0 ? remainingBudget / remainingDays : 0;
+    const savings = monthlyIncome - monthlyExpenses;
 
     setKpis({
       totalBalance,
-      monthlyBudget,
-      monthlyActual,
-      mtdSpend,
-      dailyAverage,
-      remainingAllowance,
+      monthlyIncome,
+      monthlyExpenses,
+      savings,
     });
 
     // Category spending from transactions
@@ -271,36 +285,26 @@ export default function DashboardPage() {
     return <LoadingSpinner />;
   }
 
-  const kpiCards = [
+  const summaryCards = [
     {
       title: 'Total Balance',
       value: formatIDR(kpis.totalBalance),
       icon: Wallet,
-      trend: kpis.totalBalance >= 0 ? 'positive' : 'negative',
     },
     {
-      title: 'Monthly Budget vs Actual',
-      value: `${formatIDR(kpis.monthlyActual)} / ${formatIDR(kpis.monthlyBudget)}`,
+      title: 'Monthly Income',
+      value: formatIDR(kpis.monthlyIncome),
       icon: TrendingUp,
-      trend: kpis.monthlyActual <= kpis.monthlyBudget ? 'positive' : 'negative',
     },
     {
-      title: 'MTD Spending',
-      value: formatIDR(kpis.mtdSpend),
+      title: 'Monthly Expenses',
+      value: formatIDR(kpis.monthlyExpenses),
       icon: TrendingDown,
-      trend: 'neutral',
     },
     {
-      title: 'Daily Average',
-      value: formatIDR(kpis.dailyAverage),
-      icon: Calendar,
-      trend: 'neutral',
-    },
-    {
-      title: 'Remaining Daily Allowance',
-      value: formatIDR(kpis.remainingAllowance),
+      title: 'Savings',
+      value: formatIDR(kpis.savings),
       icon: DollarSign,
-      trend: kpis.remainingAllowance >= 0 ? 'positive' : 'negative',
     },
   ];
 
@@ -308,31 +312,30 @@ export default function DashboardPage() {
     <div className="space-y-6 relative">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">Dashboard</h2>
+          <h2 className="text-3xl font-bold tracking-tight">
+            Good Morning{user?.name ? `, ${user.name}` : ''}
+          </h2>
           <p className="text-muted-foreground">
-            Overview of your financial health
+            Here is your financial overview
           </p>
         </div>
-        <Button className="fixed bottom-4 right-4 z-50 p-3 rounded-full bg-primary text-white shadow-lg" onClick={() => setFormOpen(true)}>
+        <Button
+          className="fixed bottom-4 right-4 z-50 p-3 rounded-full bg-primary text-white shadow-lg"
+          onClick={() => setFormOpen(true)}
+        >
           <Plus className="mr-2 h-4 w-4" /> New Transaction
         </Button>
       </div>
 
-      {/* KPI Cards */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-        {kpiCards.map((card, index) => (
+      {/* Summary Cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {summaryCards.map((card, index) => (
           <Card key={index}>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">
                 {card.title}
               </CardTitle>
-              <card.icon className={`h-4 w-4 ${
-                card.trend === 'positive' 
-                  ? 'text-green-600' 
-                  : card.trend === 'negative'
-                  ? 'text-red-600'
-                  : 'text-gray-600'
-              }`} />
+              <card.icon className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">{card.value}</div>

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -51,6 +51,7 @@ import TransactionForm, {
   TransactionFormValues,
 } from '@/components/transactions/transaction-form';
 import { formatDate } from '@/lib/date';
+import { useOffline } from '@/hooks/use-offline';
 
 const toCamel = (str: string) =>
   str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
@@ -95,6 +96,7 @@ export default function TransactionsPage() {
   const [search, setSearch] = useState('');
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<Transaction | undefined>();
+  const { isOnline, addOfflineChange } = useOffline();
   const [page, setPage] = useState(1);
   const pageSize = 20;
   const [total, setTotal] = useState(0);
@@ -112,7 +114,7 @@ export default function TransactionsPage() {
   }, [transactions, groupBy]);
 
   const fetchTransactions = useCallback(async () => {
-    if (!user) return;
+    if (!user || !isOnline) return;
     const params = new URLSearchParams({
       page: String(page),
       pageSize: String(pageSize),
@@ -146,6 +148,7 @@ export default function TransactionsPage() {
     setTotal(data.total);
   }, [
     user,
+    isOnline,
     page,
     pageSize,
     dateRange.from,
@@ -159,7 +162,7 @@ export default function TransactionsPage() {
   ]);
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || !isOnline) return;
 
     const fetchData = async () => {
       try {
@@ -188,6 +191,7 @@ export default function TransactionsPage() {
     fetchData();
   }, [
     user,
+    isOnline,
     accounts.length,
     categories.length,
     setAccounts,
@@ -202,15 +206,40 @@ export default function TransactionsPage() {
       actualDate: formatDate(values.actualDate),
       date: formatDate(values.actualDate),
       type: values.type,
-      accountId: values.accountId,
-      fromAccountId: values.fromAccountId,
-      toAccountId: values.toAccountId,
-      categoryId: values.categoryId,
+      accountId: values.accountId || undefined,
+      fromAccountId: values.fromAccountId || undefined,
+      toAccountId: values.toAccountId || undefined,
+      categoryId: values.categoryId || undefined,
       amount: values.amount,
-      note: values.note,
+      note: values.note || '',
       tags: values.tags || [],
     };
     const isEditing = Boolean(editing);
+
+    if (!isOnline) {
+      if (isEditing) {
+        const updated = transactions.map((tx) =>
+          tx.id === editing!.id ? { ...tx, ...payload } : tx
+        );
+        setTransactions(updated);
+        await addOfflineChange('update', 'transactions', {
+          id: editing!.id,
+          ...payload,
+        });
+      } else {
+        const tempTx: Transaction = {
+          id: `offline-${Date.now()}`,
+          userId: user.id,
+          ...payload,
+        };
+        setTransactions([tempTx, ...transactions]);
+        await addOfflineChange('create', 'transactions', payload);
+      }
+      toast.success(isEditing ? 'Transaction updated offline' : 'Transaction added offline');
+      setFormOpen(false);
+      setEditing(undefined);
+      return;
+    }
 
     let res: Response;
     if (isEditing) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { Toaster } from "@/components/ui/toaster";
 import { ThemeProvider } from "@/components/theme-provider";
+import { ServiceWorkerRegister } from "@/components/service-worker-register";
 import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -82,6 +83,9 @@ export default function RootLayout({
       <head>
         <meta name="theme-color" content="#4F46E5" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <link rel="apple-touch-icon" href="/favicon.svg" />
         <meta name="apple-mobile-web-app-title" content="monli" />
         <meta
           name="google-site-verification"
@@ -122,6 +126,7 @@ export default function RootLayout({
           {children}
           <Toaster />
         </ThemeProvider>
+        <ServiceWorkerRegister />
       </body>
     </html>
   );

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -24,23 +24,7 @@ export function MobileNav() {
   const { accounts, categories } = useAppStore();
 
   const handleAddTransaction = () => {
-    const now = new Date();
-    const dateString = now.toISOString().slice(0, 10); // YYYY-MM-DD
-    const budgetMonth = dateString.slice(0, 7); // YYYY-MM
-
-    const newTransaction: Transaction = {
-      id: "new-id",
-      userId: "user-id",
-      date: now.toISOString(),
-      budgetMonth,
-      actualDate: dateString,
-      type: "expense",
-      amount: 0,
-      note: "",
-      tags: [],
-    };
-
-    setTransaction(newTransaction);
+    setTransaction(undefined);
     setFormOpen(true);
   };
 

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -67,6 +67,15 @@ export function Sidebar() {
             );
           })}
         </nav>
+
+        <div className="mt-auto p-3">
+          <div className="rounded-lg border bg-muted/50 p-4 text-center">
+            <p className="text-sm font-medium">Upgrade Pro</p>
+            <Button asChild size="sm" className="mt-2 w-full">
+              <Link href="/upgrade">Upgrade</Link>
+            </Button>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -143,6 +152,17 @@ export function MobileSidebar() {
                 <BarChart3 className="mr-4 h-5 w-5 flex-shrink-0" />
                 Reports
               </Link>
+            </div>
+
+            <div className="mt-6 border-t border-border p-4">
+              <div className="rounded-lg bg-muted/50 p-4 text-center">
+                <p className="text-sm font-medium">Upgrade Pro</p>
+                <Button asChild size="sm" className="mt-2 w-full">
+                  <Link href="/upgrade" onClick={() => setOpen(false)}>
+                    Upgrade
+                  </Link>
+                </Button>
+              </div>
             </div>
           </nav>
         </div>

--- a/components/service-worker-register.tsx
+++ b/components/service-worker-register.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").catch(() => {
+        // noop
+      });
+    }
+  }, []);
+
+  return null;
+}

--- a/components/transactions/transaction-form.tsx
+++ b/components/transactions/transaction-form.tsx
@@ -199,7 +199,7 @@ export function TransactionForm({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         id={id}
-        className="sm:max-w-md mx-4 max-h-[90vh] overflow-y-auto"
+        className="sm:max-w-md w-full h-full sm:h-auto sm:max-h-[90vh] overflow-y-auto p-0 sm:p-6"
       >
         <DialogHeader>
           <DialogTitle>{transaction ? 'Edit Transaction' : 'Add Transaction'}</DialogTitle>

--- a/components/ui/offline-indicator.tsx
+++ b/components/ui/offline-indicator.tsx
@@ -4,24 +4,14 @@
 import { useOffline } from '@/hooks/use-offline';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Wifi, WifiOff, RefreshCw, AlertCircle } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { WifiOff, RefreshCw, AlertCircle } from 'lucide-react';
 
 export function OfflineIndicator() {
   const { isOnline, pendingSyncCount, syncPendingChanges } = useOffline();
 
-  if (isOnline && pendingSyncCount === 0) {
-    return (
-      <Badge variant="outline" className="gap-2 text-green-600 border-green-200">
-        <Wifi className="h-3 w-3" />
-        Online
-      </Badge>
-    );
-  }
-
   if (!isOnline) {
     return (
-      <Badge variant="destructive" className="gap-2">
+      <Badge variant="outline" className="gap-2 text-amber-600 border-amber-200">
         <WifiOff className="h-3 w-3" />
         Offline
       </Badge>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "monli",
+  "short_name": "monli",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#4F46E5",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/favicon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,4 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});

--- a/tests/auth/sign-in.happy.spec.ts
+++ b/tests/auth/sign-in.happy.spec.ts
@@ -13,7 +13,7 @@ import { loginUI } from '../utils/helpers';
   const userId = created.user!.id;
 
   await loginUI(page, email, password);
-  await expect(page.getByRole('heading', { name: /dashboard/i })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /good/i })).toBeVisible();
 
   // visiting sign-in when logged in should redirect
   await page.goto('/auth/sign-in');

--- a/types/index.ts
+++ b/types/index.ts
@@ -66,11 +66,9 @@ export interface Transaction {
 
 export interface DashboardKPIs {
   totalBalance: number;
-  monthlyBudget: number;
-  monthlyActual: number;
-  mtdSpend: number;
-  dailyAverage: number;
-  remainingAllowance: number;
+  monthlyIncome: number;
+  monthlyExpenses: number;
+  savings: number;
 }
 
 export interface CategorySpend {


### PR DESCRIPTION
## Summary
- redesign dashboard metrics and greeting
- add upgrade pro card to sidebar navigation
- adjust sign-in test for new heading
- ensure mobile nav plus button opens add transaction form
- streamline online status indicator for less disruptive feedback
- move offline sync routine before usage to prevent build-time errors
- allow transactions to be created or updated while offline and synced later
- make transaction dialog full-screen on mobile for easier entry
- cache data in IndexedDB and skip network fetches when offline so a refresh still shows stored info
- enable home screen installation with a web manifest, icons and service worker
- reuse favicon.svg for 192×192 and 512×512 manifest icon sizes to avoid binary upload errors

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Timed out waiting 60000ms from config.webServer)*
- `npm run build` *(fails: Missing Supabase environment variables for admin client)*


------
https://chatgpt.com/codex/tasks/task_e_68a8ae1d16f48325b4a185d87cba790a