### PR TITLE
feat: add optional account number with copy support

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -7,6 +7,7 @@ import {
   Wallet2,
   MoreHorizontal,
   Plus,
+  Copy,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -223,6 +224,22 @@ export default function AccountsPage() {
                 <p className="text-sm text-muted-foreground">
                   {account.currency}
                 </p>
+                {account.accountNumber && (
+                  <div className="mt-2 flex items-center text-sm text-muted-foreground">
+                    <span>{account.accountNumber}</span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="ml-2 h-6 w-6"
+                      onClick={() => {
+                        navigator.clipboard.writeText(account.accountNumber!);
+                        toast.success('Account number copied');
+                      }}
+                    >
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
               </CardContent>
             </Card>
           );

--- a/app/api/accounts/[id]/route.ts
+++ b/app/api/accounts/[id]/route.ts
@@ -27,6 +27,8 @@ export async function PATCH(
     if (body.openingBalance !== undefined)
       updates.opening_balance = body.openingBalance;
     if (body.archived !== undefined) updates.archived = body.archived;
+    if (body.accountNumber !== undefined)
+      updates.account_number = body.accountNumber;
 
     const { data, error } = await supabase
       .from("accounts")
@@ -52,6 +54,7 @@ export async function PATCH(
       currency: data.currency,
       openingBalance: data.opening_balance,
       archived: data.archived,
+      accountNumber: data.account_number ?? undefined,
       currentBalance: balances[data.id] ?? data.opening_balance,
     });
   } catch (e) {

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -46,6 +46,7 @@ export async function GET(req: Request) {
       currency: acc.currency,
       openingBalance: acc.opening_balance,
       archived: acc.archived,
+      accountNumber: acc.account_number ?? undefined,
       currentBalance: balances[acc.id] ?? acc.opening_balance,
     }));
 
@@ -74,6 +75,7 @@ export async function POST(req: Request) {
         currency: body.currency ?? "IDR",
         opening_balance: body.openingBalance ?? 0,
         archived: body.archived ?? false,
+        account_number: body.accountNumber ?? null,
       })
       .select("*")
       .single();
@@ -94,6 +96,7 @@ export async function POST(req: Request) {
       currency: data.currency,
       openingBalance: data.opening_balance,
       archived: data.archived,
+      accountNumber: data.account_number ?? undefined,
       currentBalance: balances[data.id] ?? data.opening_balance,
     });
   } catch (e) {

--- a/components/accounts/account-form.tsx
+++ b/components/accounts/account-form.tsx
@@ -32,6 +32,7 @@ const accountSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   type: z.enum(['bank', 'ewallet', 'cash']),
   currency: z.string().min(1, 'Currency is required'),
+  accountNumber: z.string().optional(),
   openingBalance: z.number(),
   archived: z.boolean().optional(),
 });
@@ -53,6 +54,7 @@ export function AccountForm({ account, onSuccess }: AccountFormProps) {
       name: account?.name ?? '',
       type: account?.type ?? 'bank',
       currency: account?.currency ?? 'IDR',
+      accountNumber: account?.accountNumber ?? '',
       openingBalance: account?.openingBalance ?? 0,
       archived: account?.archived ?? false,
     },
@@ -70,6 +72,7 @@ export function AccountForm({ account, onSuccess }: AccountFormProps) {
             currency: values.currency,
             opening_balance: values.openingBalance,
             archived: values.archived,
+            account_number: values.accountNumber || null,
           })
           .eq('id', account.id);
         if (error) throw error;
@@ -89,6 +92,7 @@ export function AccountForm({ account, onSuccess }: AccountFormProps) {
             currency: values.currency,
             opening_balance: values.openingBalance,
             archived: values.archived,
+            account_number: values.accountNumber || null,
           })
           .select()
           .single();
@@ -101,6 +105,7 @@ export function AccountForm({ account, onSuccess }: AccountFormProps) {
           currency: data.currency,
           openingBalance: data.opening_balance,
           archived: data.archived,
+          accountNumber: data.account_number ?? undefined,
         };
         setAccounts([...accounts, newAccount]);
         toast.success('Account created');
@@ -163,6 +168,19 @@ export function AccountForm({ account, onSuccess }: AccountFormProps) {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Currency</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="accountNumber"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Account Number (optional)</FormLabel>
               <FormControl>
                 <Input {...field} />
               </FormControl>

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -6,6 +6,7 @@ export const accountSchema = z.object({
   currency: z.string().default('IDR'),
   openingBalance: z.number().nonnegative().default(0),
   archived: z.boolean().default(false),
+  accountNumber: z.string().optional(),
 });
 
 export const categorySchema = z.object({

--- a/supabase/migrations/20240915000000_add_account_number_to_accounts.sql
+++ b/supabase/migrations/20240915000000_add_account_number_to_accounts.sql
@@ -1,0 +1,1 @@
+alter table accounts add column account_number text;

--- a/types/database.ts
+++ b/types/database.ts
@@ -41,6 +41,7 @@ export interface Database {
           currency: string;
           opening_balance: number;
           archived: boolean;
+          account_number: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -52,6 +53,7 @@ export interface Database {
           currency?: string;
           opening_balance?: number;
           archived?: boolean;
+          account_number?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -61,6 +63,7 @@ export interface Database {
           currency?: string;
           opening_balance?: number;
           archived?: boolean;
+          account_number?: string | null;
           updated_at?: string;
         };
       };

--- a/types/index.ts
+++ b/types/index.ts
@@ -14,6 +14,7 @@ export interface Account {
   openingBalance: number;
   archived: boolean;
   currentBalance?: number;
+  accountNumber?: string;
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary
- allow accounts to store optional account numbers
- show account numbers on account cards with copy-to-clipboard button
- add database migration for new account_number column

## Testing
- `npm test`
- `npm run test:e2e` *(fails: fetch failed when downloading Next.js swc package)*

------
https://chatgpt.com/codex/tasks/task_e_68ab356d78348325aa173e520898ea10