### PR TITLE
Add dashboard amount visibility toggle

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -35,6 +35,8 @@ import {
   Plus,
   ArrowUpRight,
   ArrowDownRight,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { formatDate } from '@/lib/date';
 import { useOffline } from '@/hooks/use-offline';
@@ -84,6 +86,7 @@ export default function DashboardPage() {
   });
   const [categorySpends, setCategorySpends] = useState<CategorySpend[]>([]);
   const [formOpen, setFormOpen] = useState(false);
+  const [hideAmounts, setHideAmounts] = useState(false);
   const { isOnline, addOfflineChange } = useOffline();
 
   const handleSave = async (values: TransactionFormValues) => {
@@ -348,28 +351,28 @@ export default function DashboardPage() {
   const summaryCards = [
     {
       title: 'Total Balance',
-      value: formatIDR(kpis.totalBalance),
+      value: kpis.totalBalance,
       icon: Wallet,
       delta: kpis.totalBalance - prevKpis.totalBalance,
       prev: prevKpis.totalBalance,
     },
     {
       title: 'Monthly Income',
-      value: formatIDR(kpis.monthlyIncome),
+      value: kpis.monthlyIncome,
       icon: TrendingUp,
       delta: kpis.monthlyIncome - prevKpis.monthlyIncome,
       prev: prevKpis.monthlyIncome,
     },
     {
       title: 'Monthly Expenses',
-      value: formatIDR(kpis.monthlyExpenses),
+      value: kpis.monthlyExpenses,
       icon: TrendingDown,
       delta: kpis.monthlyExpenses - prevKpis.monthlyExpenses,
       prev: prevKpis.monthlyExpenses,
     },
     {
       title: 'Savings',
-      value: formatIDR(kpis.savings),
+      value: kpis.savings,
       icon: DollarSign,
       delta: kpis.savings - prevKpis.savings,
       prev: prevKpis.savings,
@@ -387,12 +390,25 @@ export default function DashboardPage() {
             Here is your financial overview
           </p>
         </div>
-        <Button
-          className="hidden sm:inline-flex"
-          onClick={() => setFormOpen(true)}
-        >
-          <Plus className="mr-2 h-4 w-4" /> New Transaction
-        </Button>
+        <div className="flex gap-2">
+          <Button
+            className="hidden sm:inline-flex"
+            onClick={() => setFormOpen(true)}
+          >
+            <Plus className="mr-2 h-4 w-4" /> New Transaction
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setHideAmounts(prev => !prev)}
+          >
+            {hideAmounts ? (
+              <Eye className="h-4 w-4" />
+            ) : (
+              <EyeOff className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
       </div>
 
       {/* Tombol add transaction di mobile view dihilangkan karena sudah ada di mobile nav */}
@@ -416,7 +432,9 @@ export default function DashboardPage() {
                 <card.icon className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-3xl font-bold">{card.value}</div>
+                <div className="text-3xl font-bold">
+                  {hideAmounts ? '••••' : formatIDR(card.value)}
+                </div>
                 <p className="flex items-center text-xs mt-1">
                   {positive ? (
                     <ArrowUpRight className="h-4 w-4 text-green-500 mr-1" />
@@ -426,7 +444,7 @@ export default function DashboardPage() {
                   <span
                     className={positive ? 'text-green-500' : 'text-red-500'}
                   >
-                    {deltaPct}%
+                    {hideAmounts ? '--' : `${deltaPct}%`}
                   </span>
                   <span className="ml-1 text-muted-foreground">
                     vs last month
@@ -442,6 +460,7 @@ export default function DashboardPage() {
       <DashboardCharts
         transactions={transactions}
         categorySpends={categorySpends}
+        hideAmounts={hideAmounts}
       />
 
       {/* Recent Transactions */}
@@ -449,6 +468,7 @@ export default function DashboardPage() {
         transactions={transactions}
         accounts={accounts}
         categories={categories}
+        hideAmounts={hideAmounts}
       />
 
       <TransactionForm

--- a/components/dashboard/dashboard-charts.tsx
+++ b/components/dashboard/dashboard-charts.tsx
@@ -28,9 +28,10 @@ import {
 interface Props {
   transactions: Transaction[];
   categorySpends: CategorySpend[];
+  hideAmounts?: boolean;
 }
 
-export function DashboardCharts({ transactions, categorySpends }: Props) {
+export function DashboardCharts({ transactions, categorySpends, hideAmounts = false }: Props) {
   const dailyExpenses = useMemo(() => {
     const now = new Date();
     const days = eachDayOfInterval({
@@ -95,12 +96,14 @@ export function DashboardCharts({ transactions, categorySpends }: Props) {
                   axisLine={{ stroke: "hsl(var(--border))" }}
                 />
                 <YAxis
-                  tickFormatter={value => formatIDR(value)}
+                  tickFormatter={value => (hideAmounts ? "" : formatIDR(value))}
                   tick={{ fill: "hsl(var(--muted-foreground))" }}
                   axisLine={{ stroke: "hsl(var(--border))" }}
                 />
                 <Tooltip
-                  formatter={(value: number) => formatIDR(value)}
+                  formatter={(value: number) =>
+                    hideAmounts ? "••••" : formatIDR(value)
+                  }
                   labelStyle={{ color: "hsl(var(--foreground))" }}
                   contentStyle={{
                     backgroundColor: "hsl(var(--card))",
@@ -130,7 +133,9 @@ export function DashboardCharts({ transactions, categorySpends }: Props) {
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
                 <Tooltip
-                  formatter={(value: number) => formatIDR(value)}
+                  formatter={(value: number) =>
+                    hideAmounts ? "••••" : formatIDR(value)
+                  }
                   contentStyle={{
                     backgroundColor: "hsl(var(--card))",
                     border: "1px solid hsl(var(--border))",

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -32,12 +32,14 @@ interface Props {
   transactions: Transaction[];
   accounts: Account[];
   categories: Category[];
+  hideAmounts?: boolean;
 }
 
 export function RecentTransactions({
   transactions,
   accounts,
   categories,
+  hideAmounts = false,
 }: Props) {
   const [open, setOpen] = useState(false);
   const [filters, setFilters] = useState({
@@ -288,8 +290,11 @@ export function RecentTransactions({
                             : 'text-blue-600'
                         }`}
                       >
-                        {transaction.type === 'expense' ? '-' : ''}
-                        {formatIDR(transaction.amount)}
+                        {hideAmounts
+                          ? '••••'
+                          : `${
+                              transaction.type === 'expense' ? '-' : ''
+                            }${formatIDR(transaction.amount)}`}
                       </p>
                     </div>
                   </m.div>


### PR DESCRIPTION
## Summary
- add toggle to hide or show financial amounts on dashboard
- propagate amount hiding to charts and recent transactions

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68abeec00b60832598fcbdf4216a7dca