### PR TITLE
style: redesign account cards

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -1,26 +1,14 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import {
-  Building2,
-  Smartphone,
-  Wallet2,
-  MoreHorizontal,
-  Plus,
-  Copy,
-} from 'lucide-react';
+import { MoreHorizontal, Plus, Copy } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { useAppStore } from '@/lib/store';
 import { supabase } from '@/lib/supabase';
 import { formatCurrency } from '@/lib/currency';
 import { Account } from '@/types';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -57,11 +45,14 @@ import {
   PaginationPrevious,
 } from '@/components/ui/pagination';
 
-const typeIcons = {
-  bank: Building2,
-  ewallet: Smartphone,
-  cash: Wallet2,
+const typeLabels: Record<Account['type'], string> = {
+  bank: 'Bank Account',
+  ewallet: 'E-Wallet',
+  cash: 'Cash',
 };
+
+const formatAccountNumber = (num: string) =>
+  num.replace(/(\d{4})(?=\d)/g, '$1 ');
 
 export default function AccountsPage() {
   const {
@@ -152,95 +143,117 @@ export default function AccountsPage() {
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {accounts.map((account) => {
-          const Icon = typeIcons[account.type];
           const balance = account.currentBalance ?? 0;
           return (
             <Card
               key={account.id}
-              className="bg-muted/50 hover:shadow-md transition-shadow"
+              className="relative h-56 overflow-hidden rounded-xl text-white shadow hover:shadow-lg transition-transform hover:scale-105"
             >
-              <CardHeader className="flex flex-row items-center justify-between">
-                <CardTitle className="flex items-center space-x-2">
-                  <Icon className="h-5 w-5" />
-                  <span>{account.name}</span>
-                  {account.archived && (
-                    <Badge variant="secondary">Archived</Badge>
-                  )}
-                </CardTitle>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="icon">
-                      <MoreHorizontal className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setEditingAccount(account);
-                        setDialogOpen(true);
-                      }}
-                    >
-                      Edit
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() =>
-                        handleArchive(account.id, !account.archived)
-                      }
-                    >
-                      {account.archived ? 'Unarchive' : 'Archive'}
-                    </DropdownMenuItem>
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <DropdownMenuItem className="text-destructive">
-                          Delete
+              <div className="absolute inset-0 bg-gradient-to-br from-gray-800 to-gray-900" />
+              <div className="relative z-10 flex h-full flex-col justify-between p-5">
+                <div className="flex items-start justify-between">
+                  <span className="text-sm uppercase tracking-wide">
+                    {typeLabels[account.type]}
+                  </span>
+                  <div className="flex items-center space-x-2">
+                    <span className="text-sm">{account.name}</span>
+                    {account.archived && (
+                      <Badge
+                        variant="secondary"
+                        className="bg-white/20 text-white"
+                      >
+                        Archived
+                      </Badge>
+                    )}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-white hover:bg-white/20"
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => {
+                            setEditingAccount(account);
+                            setDialogOpen(true);
+                          }}
+                        >
+                          Edit
                         </DropdownMenuItem>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>
-                            Delete account?
-                          </AlertDialogTitle>
-                          <AlertDialogDescription>
-                            This action cannot be undone.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Cancel</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => handleDelete(account.id)}
-                          >
-                            Delete
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">
-                  {formatCurrency(balance, account.currency)}
+                        <DropdownMenuItem
+                          onClick={() =>
+                            handleArchive(account.id, !account.archived)
+                          }
+                        >
+                          {account.archived ? 'Unarchive' : 'Archive'}
+                        </DropdownMenuItem>
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem className="text-destructive">
+                              Delete
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                Delete account?
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                This action cannot be undone.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => handleDelete(account.id)}
+                              >
+                                Delete
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
                 </div>
-                <p className="text-sm text-muted-foreground">
-                  {account.currency}
-                </p>
                 {account.accountNumber && (
-                  <div className="mt-2 flex items-center text-sm text-muted-foreground">
-                    <span>{account.accountNumber}</span>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="ml-2 h-6 w-6"
-                      onClick={() => {
-                        navigator.clipboard.writeText(account.accountNumber!);
-                        toast.success('Account number copied');
-                      }}
-                    >
-                      <Copy className="h-4 w-4" />
-                    </Button>
+                  <div className="relative mt-6">
+                    <div className="flex items-center">
+                      <div className="mr-4 h-8 w-12 rounded-sm bg-gradient-to-br from-yellow-300 to-yellow-500" />
+                      <div className="font-mono text-xl tracking-widest">
+                        {formatAccountNumber(account.accountNumber)}
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="ml-auto h-6 w-6 text-white hover:bg-white/20"
+                        onClick={() => {
+                          navigator.clipboard.writeText(account.accountNumber!);
+                          toast.success('Account number copied');
+                        }}
+                      >
+                        <Copy className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <div className="absolute left-16 top-full mt-1 text-xs font-mono">
+                      {account.accountNumber.slice(0, 4)}
+                    </div>
                   </div>
                 )}
-              </CardContent>
+                <div className="flex items-end justify-between">
+                  <span className="text-sm">{user?.name}</span>
+                  <div className="text-right">
+                    <p className="text-[10px] uppercase">Balance</p>
+                    <p className="font-mono text-sm">
+                      {formatCurrency(balance, account.currency)}
+                    </p>
+                  </div>
+                </div>
+              </div>
             </Card>
           );
         })}


### PR DESCRIPTION
## Summary
- restyle account cards with gradient credit-card look
- add helper to format account numbers
- mimic credit card layout with chip, type label, and user name

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac28f1a0688325bda5f9434004a5b3