### PR TITLE
Redirect root path to login or dashboard

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -75,6 +75,13 @@ export async function middleware(request: NextRequest) {
     // Continue without user - will be handled by route protection below
   }
 
+  // Redirect root path directly to auth or dashboard
+  if (request.nextUrl.pathname === "/") {
+    return NextResponse.redirect(
+      new URL(user ? "/dashboard" : "/auth/sign-in", request.url),
+    );
+  }
+
   // Protect dashboard routes
   if (
     request.nextUrl.pathname.startsWith("/dashboard") ||

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "monli",
   "short_name": "monli",
-  "start_url": "/",
+  "start_url": "/auth/sign-in",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#4F46E5",


### PR DESCRIPTION
## Summary
- Redirect root path to sign-in or dashboard based on auth state
- Set PWA start URL to sign-in so installed app skips landing page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad396767388325b52dac56d4a29cd3