### PR TITLE
feat: suggest tags from note

### DIFF
--- a/components/transactions/transaction-form.tsx
+++ b/components/transactions/transaction-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 
@@ -157,7 +157,7 @@ export function TransactionForm({
   const [tagInput, setTagInput] = useState('');
   const [suggestedTags, setSuggestedTags] = useState<string[]>([]);
 
-  const note = form.watch('note');
+  const note = useWatch({ control: form.control, name: 'note' });
 
   useEffect(() => {
     const handler = setTimeout(async () => {


### PR DESCRIPTION
## Summary
- infer tag suggestions via `infer_tags` RPC when note is edited
- display suggested tag chips that can be added alongside manual tags

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad74a202548325a4059effb752e844