### PR TITLE
Improve SEO metadata for auth and zakat pages

### DIFF
--- a/app/auth/sign-in/head.tsx
+++ b/app/auth/sign-in/head.tsx
@@ -1,0 +1,13 @@
+export default function Head() {
+  return (
+    <>
+      <title>Masuk - Monli</title>
+      <meta
+        name="description"
+        content="Masuk ke akun Monli untuk mengelola keuangan pribadi kamu."
+      />
+      <meta name="robots" content="noindex, nofollow" />
+    </>
+  );
+}
+

--- a/app/auth/sign-up/head.tsx
+++ b/app/auth/sign-up/head.tsx
@@ -1,0 +1,13 @@
+export default function Head() {
+  return (
+    <>
+      <title>Daftar - Monli</title>
+      <meta
+        name="description"
+        content="Buat akun Monli untuk mulai mengatur dan memantau keuangan pribadimu."
+      />
+      <meta name="robots" content="noindex, nofollow" />
+    </>
+  );
+}
+

--- a/app/zakat/page.tsx
+++ b/app/zakat/page.tsx
@@ -1,6 +1,13 @@
 import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
 import { createServerClient } from '@/lib/supabase/server';
 import ZakatCalculator from './zakat-calculator';
+
+export const metadata: Metadata = {
+  title: 'Kalkulator Zakat - Monli',
+  description: 'Hitung kewajiban zakatmu dengan kalkulator zakat Monli.',
+  robots: { index: false, follow: false },
+};
 
 export default async function ZakatPage() {
   const supabase = createServerClient();

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,7 @@
 # robots.txt for Google Search indexing
 User-agent: *
 Allow: /
+Disallow: /auth/
+Disallow: /zakat
 
 Sitemap: https://monli.fun/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,12 +4,6 @@
     <loc>https://monli.fun/</loc>
   </url>
   <url>
-    <loc>https://monli.fun/auth/sign-in</loc>
-  </url>
-  <url>
-    <loc>https://monli.fun/auth/sign-up</loc>
-  </url>
-  <url>
     <loc>https://monli.fun/dashboard</loc>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- localize auth page metadata to Indonesian and update brand capitalization
- adjust zakat calculator metadata to use proper brand name
- disallow auth and zakat routes in robots.txt and drop auth pages from sitemap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad85c16d4c8325ba21de5bd8610117