### PR TITLE
fix: redirect to login after sign out

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -29,6 +29,7 @@ function UserNav() {
     try {
       await signOut();
       toast.success('Signed out successfully');
+      window.location.href = '/auth/sign-in';
     } catch (error) {
       toast.error('Failed to sign out');
     }


### PR DESCRIPTION
## Summary
- redirect to sign-in page after user signs out

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: Error: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68ada06270708325a2bd1db62c38b71c