### PR TITLE
feat: support configurable budget cut-off day

### DIFF
--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useAppStore } from '@/lib/store';
+import { getBudgetMonth } from '@/lib/date';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -48,8 +50,9 @@ interface SummaryResponse {
 }
 
 export default function ReportsPage() {
+  const { user } = useAppStore();
   const now = new Date();
-  const defaultMonth = now.toISOString().slice(0, 7);
+  const defaultMonth = getBudgetMonth(now, user?.budgetCutoffDay ?? 31);
   const defaultYear = String(now.getUTCFullYear());
 
   const [month, setMonth] = useState(defaultMonth);

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -61,7 +61,7 @@ export default function SettingsPage() {
 
   const profileForm = useForm<ProfileFormValues>({
     resolver: zodResolver(profileFormSchema),
-    defaultValues: { name: '', defaultCurrency: 'IDR' },
+    defaultValues: { name: '', defaultCurrency: 'IDR', budgetCutoffDay: 31 },
   });
 
   useEffect(() => {
@@ -70,7 +70,8 @@ export default function SettingsPage() {
       .then((data) => {
         profileForm.reset({
           name: data.name,
-          defaultCurrency: data.defaultCurrency || 'IDR',
+          defaultCurrency: data.default_currency || 'IDR',
+          budgetCutoffDay: data.budget_cutoff_day || 31,
         });
         setEmail(data.email);
       });
@@ -192,6 +193,19 @@ export default function SettingsPage() {
                             <SelectItem value="EUR">EUR</SelectItem>
                           </SelectContent>
                         </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={profileForm.control}
+                  name="budgetCutoffDay"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Budget cut-off day</FormLabel>
+                      <FormControl>
+                        <Input type="number" min={1} max={31} {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
     const user = await getUser();
       const { data, error } = await supabase
         .from('profiles')
-        .select('id, email, name, default_currency, onboarding_completed')
+        .select('id, email, name, default_currency, onboarding_completed, budget_cutoff_day')
         .eq('id', user.id)
         .single();
     if (error) {
@@ -22,6 +22,7 @@ export async function GET() {
         name: data.name,
         defaultCurrency: data.default_currency,
         onboardingCompleted: data.onboarding_completed,
+        budgetCutoffDay: data.budget_cutoff_day,
       });
   } catch (e) {
     return NextResponse.json({ error: (e as Error).message }, { status: 401 });
@@ -43,9 +44,10 @@ export async function PATCH(req: Request) {
         .update({
           name: body.name,
           default_currency: body.defaultCurrency,
+          budget_cutoff_day: body.budgetCutoffDay,
         })
         .eq('id', user.id)
-        .select('id, email, name, default_currency, onboarding_completed')
+        .select('id, email, name, default_currency, onboarding_completed, budget_cutoff_day')
         .single();
     if (error || !data) {
       return NextResponse.json({ error: error?.message || 'Not found' }, { status: 404 });
@@ -56,6 +58,7 @@ export async function PATCH(req: Request) {
         name: data.name,
         defaultCurrency: data.default_currency,
         onboardingCompleted: data.onboarding_completed,
+        budgetCutoffDay: data.budget_cutoff_day,
       });
   } catch (e) {
     return NextResponse.json({ error: (e as Error).message }, { status: 401 });

--- a/app/api/settings/profile/route.ts
+++ b/app/api/settings/profile/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
     const user = await getUser();
     const { data, error } = await supabase
       .from('profiles')
-      .select('id, email, name, default_currency, created_at, updated_at')
+      .select('id, email, name, default_currency, budget_cutoff_day, created_at, updated_at')
       .eq('id', user.id)
       .single();
     if (error || !data) {
@@ -37,12 +37,15 @@ export async function PATCH(req: Request) {
       ...(body.defaultCurrency !== undefined
         ? { default_currency: body.defaultCurrency }
         : {}),
+      ...(body.budgetCutoffDay !== undefined
+        ? { budget_cutoff_day: body.budgetCutoffDay }
+        : {}),
     };
     const { data, error } = await supabase
       .from('profiles')
       .update(update)
       .eq('id', user.id)
-      .select('id, email, name, default_currency, created_at, updated_at')
+      .select('id, email, name, default_currency, budget_cutoff_day, created_at, updated_at')
       .single();
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });

--- a/components/budgets/budget-form-dialog.tsx
+++ b/components/budgets/budget-form-dialog.tsx
@@ -6,6 +6,7 @@ import { supabase } from '@/lib/supabase';
 import { Budget, Category } from '@/types';
 import { toast } from 'sonner';
 import { formatIDR, parseIDR } from '@/lib/currency';
+import { getBudgetMonth } from '@/lib/date';
 import {
   Dialog,
   DialogContent,
@@ -49,7 +50,11 @@ type BudgetFormDialogProps = {
 export function BudgetFormDialog({ open, onOpenChange }: BudgetFormDialogProps) {
   const { user, budgets, setBudgets } = useAppStore();
   const [categories, setCategories] = useState<Category[]>([]);
-  const [month, setMonth] = useState<string>(() => new Date().toISOString().slice(0, 7));
+  const initialMonth = getBudgetMonth(
+    new Date(),
+    user?.budgetCutoffDay ?? 31,
+  );
+  const [month, setMonth] = useState<string>(initialMonth);
   const [total, setTotal] = useState(0);
   const [items, setItems] = useState<ItemInput[]>([{ categoryId: '', amount: '' }]);
   const [submitting, setSubmitting] = useState(false);
@@ -111,7 +116,9 @@ export function BudgetFormDialog({ open, onOpenChange }: BudgetFormDialogProps) 
       setBudgets([...budgets, newBudget]);
       toast.success('Budget created');
       onOpenChange(false);
-      setMonth(new Date().toISOString().slice(0, 7));
+      setMonth(
+        getBudgetMonth(new Date(), user?.budgetCutoffDay ?? 31),
+      );
       setTotal(0);
       setItems([{ categoryId: '', amount: '' }]);
     } else {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -87,6 +87,7 @@ export async function getCurrentUser(): Promise<User | null> {
     email: profile.email,
     name: profile.name,
     defaultCurrency: profile.default_currency,
+    budgetCutoffDay: profile.budget_cutoff_day ?? 31,
     onboardingCompleted: profile.onboarding_completed,
   };
 }

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -17,4 +17,18 @@ export function formatDate(date: Date) {
   return new Intl.DateTimeFormat('en-CA', { timeZone: TIMEZONE }).format(date);
 }
 
+export function getDaysInMonth(date: Date): number {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0)).getUTCDate();
+}
+
+export function getBudgetMonth(date: Date, cutoffDay: number): string {
+  const daysInMonth = getDaysInMonth(date);
+  const cutoff = Math.min(cutoffDay, daysInMonth);
+  if (date.getUTCDate() > cutoff) {
+    const next = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1));
+    return `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}`;
+  }
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
 export { TIMEZONE };

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -21,6 +21,7 @@ export const currencyCodes = ['IDR', 'USD', 'EUR'] as const;
 export const profileSchema = z.object({
   name: z.string().min(1).max(100),
   defaultCurrency: z.enum(currencyCodes),
+  budgetCutoffDay: z.number().int().min(1).max(31).default(31),
 });
 
 export const profilePatchSchema = profileSchema.partial();

--- a/supabase/migrations/20241015000000_add_budget_cutoff_day_to_profiles.sql
+++ b/supabase/migrations/20241015000000_add_budget_cutoff_day_to_profiles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles ADD COLUMN budget_cutoff_day integer NOT NULL DEFAULT 31;

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,6 +3,7 @@ export interface User {
   email: string;
   name: string;
   defaultCurrency: string;
+  budgetCutoffDay: number;
   onboardingCompleted: boolean;
 }
 


### PR DESCRIPTION
## Summary
- allow users to set a monthly budget cut-off day
- compute budget months based on the cut-off and apply across UI and APIs
- store cut-off day in profiles with migration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adcab4d5988325b3e7a07a2dba2199