### PR TITLE
link accounts to filtered transactions

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { MoreHorizontal, Plus, Copy } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -63,6 +64,8 @@ export default function AccountsPage() {
     loading,
     setLoading,
   } = useAppStore();
+
+  const router = useRouter();
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingAccount, setEditingAccount] = useState<Account | null>(null);
@@ -160,7 +163,10 @@ export default function AccountsPage() {
           return (
             <Card
               key={account.id}
-              className="relative h-56 overflow-hidden rounded-xl text-white shadow hover:shadow-lg transition-transform hover:scale-105"
+              onClick={() =>
+                router.push(`/transactions?accountId=${account.id}`)
+              }
+              className="relative h-56 overflow-hidden rounded-xl text-white shadow hover:shadow-lg transition-transform hover:scale-105 cursor-pointer"
             >
               <div className="absolute inset-0 bg-gradient-to-br from-gray-800 to-gray-900" />
               <div className="relative z-10 flex h-full flex-col justify-between p-5">
@@ -184,6 +190,7 @@ export default function AccountsPage() {
                           variant="ghost"
                           size="icon"
                           className="text-white hover:bg-white/20"
+                          onClick={(e) => e.stopPropagation()}
                         >
                           <MoreHorizontal className="h-4 w-4" />
                         </Button>
@@ -244,7 +251,8 @@ export default function AccountsPage() {
                         variant="ghost"
                         size="icon"
                         className="ml-auto h-6 w-6 text-white hover:bg-white/20"
-                        onClick={() => {
+                        onClick={(e) => {
+                          e.stopPropagation();
                           navigator.clipboard.writeText(account.accountNumber!);
                           toast.success('Account number copied');
                         }}

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   ChangeEvent,
 } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { format, parseISO } from 'date-fns';
 import * as LucideIcons from 'lucide-react';
 import { Plus, Pencil, Trash, Calendar as CalendarIcon } from 'lucide-react';
@@ -92,6 +93,9 @@ export default function TransactionsPage() {
     setTransactions,
   } = useAppStore();
 
+  const searchParams = useSearchParams();
+  const initialAccountFilter = searchParams.get('accountId') ?? 'all';
+
   const [dateRange, setDateRange] = useState<DateRange>({
     from: undefined,
     to: undefined,
@@ -101,7 +105,7 @@ export default function TransactionsPage() {
     setDateRange(range ?? { from: undefined, to: undefined });
     setPage(1);
   };
-  const [accountFilter, setAccountFilter] = useState('all');
+  const [accountFilter, setAccountFilter] = useState(initialAccountFilter);
   const [categoryFilter, setCategoryFilter] = useState('all');
   const [typeFilter, setTypeFilter] = useState('all');
   const [search, setSearch] = useState('');

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import Link from 'next/link';
 import { LazyMotion, m } from 'framer-motion';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -68,6 +69,11 @@ export function RecentTransactions({
       return true;
     });
   }, [transactions, filters]);
+
+  const displayedTransactions = useMemo(
+    () => filteredTransactions.slice(0, 5),
+    [filteredTransactions]
+  );
 
   const loadMotionFeatures = () =>
     import('framer-motion').then((res) => res.domAnimation);
@@ -200,14 +206,14 @@ export function RecentTransactions({
           </CollapsibleContent>
         </CardHeader>
         <CardContent>
-          {filteredTransactions.length === 0 ? (
+          {displayedTransactions.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-4">
               No transactions found.
             </p>
           ) : (
             <LazyMotion features={loadMotionFeatures}>
               <div className="divide-y rounded-md border">
-                {filteredTransactions.map((transaction) => (
+                {displayedTransactions.map((transaction) => (
                   <m.div
                     key={transaction.id}
                     className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 p-4 hover:bg-muted/50 transition-colors"
@@ -292,11 +298,16 @@ export function RecentTransactions({
                         {formatIDR(transaction.amount)}
                       </p>
                     </div>
-                  </m.div>
-                ))}
-              </div>
-            </LazyMotion>
+                    </m.div>
+                  ))}
+                </div>
+              </LazyMotion>
           )}
+          <div className="mt-4 flex justify-center">
+            <Button asChild variant="outline" size="sm">
+              <Link href="/transactions">View all transactions</Link>
+            </Button>
+          </div>
         </CardContent>
       </Collapsible>
     </Card>


### PR DESCRIPTION
## Summary
- make account cards clickable to view their transactions
- read `accountId` from query string on transactions page for automatic filter
- show only the five most recent dashboard transactions with a link to view all

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba7fa42390832582b15a832acaac04