### PR TITLE
link accounts to filtered transactions

### DIFF
--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   ChangeEvent,
 } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { format, parseISO } from 'date-fns';
 import * as LucideIcons from 'lucide-react';
 import { Plus, Pencil, Trash, Calendar as CalendarIcon } from 'lucide-react';
@@ -92,6 +93,9 @@ export default function TransactionsPage() {
     setTransactions,
   } = useAppStore();
 
+  const searchParams = useSearchParams();
+  const initialAccountFilter = searchParams.get('accountId') ?? 'all';
+
   const [dateRange, setDateRange] = useState<DateRange>({
     from: undefined,
     to: undefined,
@@ -101,7 +105,7 @@ export default function TransactionsPage() {
     setDateRange(range ?? { from: undefined, to: undefined });
     setPage(1);
   };
-  const [accountFilter, setAccountFilter] = useState('all');
+  const [accountFilter, setAccountFilter] = useState(initialAccountFilter);
   const [categoryFilter, setCategoryFilter] = useState('all');
   const [typeFilter, setTypeFilter] = useState('all');
   const [search, setSearch] = useState('');

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import Link from 'next/link';
 import { LazyMotion, m } from 'framer-motion';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -68,6 +69,11 @@ export function RecentTransactions({
       return true;
     });
   }, [transactions, filters]);
+
+  const displayedTransactions = useMemo(
+    () => filteredTransactions.slice(0, 5),
+    [filteredTransactions]
+  );
 
   const loadMotionFeatures = () =>
     import('framer-motion').then((res) => res.domAnimation);
@@ -200,14 +206,14 @@ export function RecentTransactions({
           </CollapsibleContent>
         </CardHeader>
         <CardContent>
-          {filteredTransactions.length === 0 ? (
+          {displayedTransactions.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-4">
               No transactions found.
             </p>
           ) : (
             <LazyMotion features={loadMotionFeatures}>
               <div className="divide-y rounded-md border">
-                {filteredTransactions.map((transaction) => (
+                {displayedTransactions.map((transaction) => (
                   <m.div
                     key={transaction.id}
                     className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 p-4 hover:bg-muted/50 transition-colors"
@@ -292,11 +298,16 @@ export function RecentTransactions({
                         {formatIDR(transaction.amount)}
                       </p>
                     </div>
-                  </m.div>
-                ))}
-              </div>
-            </LazyMotion>
+                    </m.div>
+                  ))}
+                </div>
+              </LazyMotion>
           )}
+          <div className="mt-4 flex justify-center">
+            <Button asChild variant="outline" size="sm">
+              <Link href="/transactions">View all transactions</Link>
+            </Button>
+          </div>
         </CardContent>
       </Collapsible>
     </Card>

--- a/public/card-bg.svg
+++ b/public/card-bg.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 250" fill="none">
+  <rect width="400" height="250" fill="#0f0f0f"/>
+  <path d="M-40 80 C40 -20 160 -20 240 80 S440 180 360 260 L-40 260 Z" fill="#ff1e56"/>
+  <path d="M160 -40 C220 40 220 120 160 200 S100 280 40 200 L-40 80 Z" fill="#ffac41"/>
+  <path d="M240 120 C320 40 360 40 440 120 L440 260 L240 260 Z" fill="#05dfd7"/>
+</svg>


### PR DESCRIPTION
## Summary
- make account cards clickable to view their transactions
- read `accountId` from query string on transactions page for automatic filter
- show only the five most recent dashboard transactions with a link to view all
- restyle account cards with custom background to match provided design
- compute dashboard total balance from account balances to include older transactions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba7fa42390832582b15a832acaac04