### PR TITLE
Redesign marketing hero section

### DIFF
--- a/components/marketing/hero.tsx
+++ b/components/marketing/hero.tsx
@@ -1,12 +1,74 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef } from "react";
 import { gsap } from "gsap";
 import { TextPlugin } from "gsap/TextPlugin";
 
 import { Button } from "@/components/ui/button";
+
+const accountCards = [
+  {
+    name: "Main Wallet",
+    balance: "Rp 12.500.000",
+    label: "Spending",
+    accent: "from-primary/80 to-primary",
+    style: {
+      transform: "rotate(-16deg) translateY(32px) scale(0.9)",
+      zIndex: 5,
+      opacity: 0.65,
+    },
+    icon: "💳",
+  },
+  {
+    name: "Bills Reserve",
+    balance: "Rp 6.200.000",
+    label: "Essentials",
+    accent: "from-blue-500/60 to-blue-500",
+    style: {
+      transform: "rotate(-8deg) translateY(16px) scale(0.95)",
+      zIndex: 10,
+      opacity: 0.8,
+    },
+    icon: "📦",
+  },
+  {
+    name: "Family Budget",
+    balance: "Rp 9.850.000",
+    label: "Shared",
+    accent: "from-amber-500/70 to-amber-500",
+    style: {
+      transform: "translateY(0px) scale(1)",
+      zIndex: 20,
+      opacity: 1,
+    },
+    icon: "🏠",
+  },
+  {
+    name: "Travel Fund",
+    balance: "Rp 3.400.000",
+    label: "Savings",
+    accent: "from-emerald-500/70 to-emerald-500",
+    style: {
+      transform: "rotate(8deg) translateY(16px) scale(0.95)",
+      zIndex: 10,
+      opacity: 0.8,
+    },
+    icon: "🧳",
+  },
+  {
+    name: "Dream Projects",
+    balance: "Rp 2.250.000",
+    label: "Goals",
+    accent: "from-purple-500/70 to-purple-500",
+    style: {
+      transform: "rotate(16deg) translateY(32px) scale(0.9)",
+      zIndex: 5,
+      opacity: 0.65,
+    },
+    icon: "✨",
+  },
+];
 
 export function Hero() {
   const sectionRef = useRef<HTMLDivElement>(null);
@@ -42,236 +104,152 @@ export function Hero() {
       ref={sectionRef}
       className="relative overflow-hidden py-12 sm:py-20 lg:py-32"
     >
-      {/* Enhanced Background Effects */}
-      <div className="absolute inset-0 bg-gradient-to-br from-primary/15 via-primary/8 to-transparent" />
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,hsl(var(--primary)/0.2),transparent_60%)]" />
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,hsl(var(--primary)/0.15),transparent_70%)]" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,hsl(var(--primary)/0.05),transparent_50%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,hsl(var(--primary)/0.14),transparent_55%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,hsl(var(--primary)/0.1),transparent_60%)]" />
+      <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-background/40 to-transparent" />
 
-      {/* Animated Grid Pattern - Hidden on mobile for performance */}
-      <div className="absolute inset-0 opacity-30 hidden sm:block">
-        <div
-          className="absolute inset-0 animate-pulse"
-          style={{
-            backgroundImage: `radial-gradient(circle at 1px 1px, hsl(var(--primary)) 1px, transparent 0)`,
-            backgroundSize: "32px 32px",
-            animation: "float 6s ease-in-out infinite",
-          }}
-        />
+      <div className="absolute inset-x-0 top-20 flex justify-center opacity-20">
+        <div className="h-40 w-[36rem] rounded-full bg-gradient-to-r from-primary/60 via-primary/20 to-primary/60 blur-3xl" />
       </div>
 
-      {/* Floating Elements */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-primary/8 rounded-full blur-3xl animate-float" />
-        <div
-          className="absolute top-3/4 right-1/4 w-[32rem] h-[32rem] bg-primary/5 rounded-full blur-3xl animate-float"
-          style={{ animationDelay: "2s" }}
-        />
-        <div
-          className="absolute top-1/2 left-3/4 w-64 h-64 bg-primary/10 rounded-full blur-2xl animate-float"
-          style={{ animationDelay: "1s" }}
-        />
-        <div className="absolute top-1/6 right-1/6 w-40 h-40 bg-gradient-to-r from-primary/6 to-primary/4 rounded-full blur-xl animate-pulse-slow" />
-      </div>
+      <div className="relative mx-auto max-w-6xl px-4">
+        <div className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-background/60 p-8 shadow-[0_40px_120px_-40px_hsl(var(--primary)/0.35)] backdrop-blur-xl sm:p-12 lg:p-16">
+          <div className="pointer-events-none absolute -inset-px rounded-[2.5rem] bg-gradient-to-br from-white/10 via-white/5 to-transparent" />
 
-      <div className="relative mx-auto max-w-7xl px-4 text-center">
-        <div className="mx-auto max-w-4xl">
-          {/* Badge */}
-          <div className="hero-animate mb-8 inline-flex items-center gap-2 rounded-full bg-primary/10 border border-primary/20 px-4 py-2 text-sm font-medium text-primary backdrop-blur-sm">
-            <div className="w-2 h-2 bg-primary rounded-full animate-pulse"></div>
-            Now in Beta - Join early adopters
-          </div>
-
-          <h1 className="hero-animate text-4xl font-extrabold tracking-tight text-foreground sm:text-6xl lg:text-7xl leading-tight">
-            <span className="block mb-2">Budget monthly,</span>
-            <span className="relative block">
-              <span
-                ref={trackRef}
-                className="bg-gradient-to-r from-primary via-primary to-primary/70 bg-clip-text text-transparent animate-pulse"
-              >
-                track daily
-              </span>
-              <svg
-                className="absolute -bottom-3 left-0 h-4 w-full text-primary/40 animate-pulse"
-                viewBox="0 0 300 16"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M2 10c49.7-3 99.4-4.5 149-3.5 49.7 1.2 99.3 4.5 149 3.5"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                  strokeLinecap="round"
-                />
-              </svg>
-            </span>
-          </h1>
-
-          <p className="hero-animate mx-auto mt-8 max-w-2xl text-xl leading-8 text-muted-foreground/90">
-            Take control of your finances with intelligent budgeting, real-time
-            tracking, and insights across all your accounts.
-          </p>
-
-          <div className="hero-animate mt-10 flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-4">
-            <Button
-              asChild
-              size="lg"
-              className="group relative rounded-2xl px-10 py-5 text-lg font-semibold bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70 shadow-lg hover:shadow-xl hover:shadow-primary/25 transition-all duration-300 transform hover:scale-105"
-            >
-              <Link href="/auth/sign-up" className="flex items-center gap-2">
-                <span className="relative z-10">Start Free Trial</span>
+          <div className="relative">
+            <div className="hero-animate flex items-center justify-between gap-4 pb-12">
+              <div className="flex flex-1 justify-center gap-3">
+                {["Dashboard", "Budgets", "Insights"].map((item, index) => (
+                  <span
+                    key={item}
+                    className={`rounded-full border px-4 py-1 text-sm font-semibold transition-colors ${
+                      index === 0
+                        ? "border-primary/40 bg-primary/10 text-primary"
+                        : "border-white/10 bg-white/5 text-muted-foreground"
+                    }`}
+                  >
+                    {item}
+                  </span>
+                ))}
+              </div>
+              <div className="hidden shrink-0 text-primary sm:flex">
                 <svg
-                  className="ml-3 h-5 w-5 transition-transform group-hover:translate-x-1"
-                  fill="none"
-                  stroke="currentColor"
+                  className="h-5 w-5"
                   viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
+                    d="M12 3l1.77 3.59 3.98.58-2.88 2.81.68 3.95L12 12.97l-3.55 1.96.68-3.95-2.88-2.81 3.98-.58L12 3z"
+                    stroke="currentColor"
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13 7l5 5m0 0l-5 5m5-5H6"
-                  />
-                </svg>
-                <div className="absolute inset-0 rounded-2xl bg-white/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-              </Link>
-            </Button>
-            <Button
-              asChild
-              variant="outline"
-              size="lg"
-              className="group rounded-2xl px-10 py-5 text-lg font-semibold border-2 border-primary/30 hover:border-primary/50 hover:bg-primary/5 backdrop-blur-sm transition-all duration-300 transform hover:scale-105"
-            >
-              <Link href="#features" className="flex items-center gap-2">
-                <svg
-                  className="mr-3 h-5 w-5 transition-transform group-hover:scale-110"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 14l-7 7m0 0l-7-7m7 7V3"
-                  />
-                </svg>
-                Learn More
-              </Link>
-            </Button>
-          </div>
-
-          {/* Trust Indicators */}
-          <div className="hero-animate flex flex-wrap items-center justify-center gap-6 sm:gap-8 text-sm text-muted-foreground pt-8">
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-              <span>No bank connection required</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-              <span>100% private & secure</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-purple-500 rounded-full"></div>
-              <span>Free forever</span>
-            </div>
-          </div>
-        </div>
-
-        {/* Enhanced Feature highlights */}
-        <div className="mt-20 grid grid-cols-1 gap-6 sm:grid-cols-3 px-4 sm:px-0">
-          {[
-            {
-              icon: "M5 13l4 4L19 7",
-              text: "100% Free",
-              delay: "0s",
-              gradient: "from-emerald-500 to-teal-600",
-            },
-            {
-              icon: "M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z",
-              text: "Secure & Private",
-              delay: "0.2s",
-              gradient: "from-blue-500 to-indigo-600",
-            },
-            {
-              icon: "M13 10V3L4 14h7v7l9-11h-7z",
-              text: "Lightning Fast",
-              delay: "0.4s",
-              gradient: "from-purple-500 to-pink-600",
-            },
-          ].map((item, index) => (
-            <div
-              key={index}
-              className="group card-hover-glow surface-elevated rounded-3xl px-8 py-6 text-center transition-all duration-500 transform hover:scale-105 hover:-translate-y-2"
-              style={{ animationDelay: item.delay }}
-            >
-              <div
-                className={`inline-flex items-center justify-center w-12 h-12 rounded-2xl bg-gradient-to-br ${item.gradient} mb-4 group-hover:scale-110 transition-transform duration-300`}
-              >
-                <svg
-                  className="h-6 w-6 text-white"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2.5}
-                    d={item.icon}
                   />
                 </svg>
               </div>
-              <h3 className="font-semibold text-foreground mb-2">
-                {item.text}
-              </h3>
-              <div
-                className={`w-full h-1 rounded-full bg-gradient-to-r ${item.gradient} opacity-60 group-hover:opacity-100 transition-opacity`}
-              ></div>
             </div>
-          ))}
-        </div>
 
-        {/* App Preview Mockup */}
-        <div className="mt-20 relative">
-          <div className="mx-auto max-w-4xl">
-            <div className="relative rounded-3xl bg-gradient-to-br from-gray-900 to-gray-800 p-8 shadow-2xl shadow-primary/20">
-              <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-primary/10 to-transparent" />
-              <div className="relative">
-                <div className="flex items-center gap-3 mb-6">
-                  <div className="flex gap-2">
-                    <div className="w-3 h-3 bg-red-500 rounded-full"></div>
-                    <div className="w-3 h-3 bg-yellow-500 rounded-full"></div>
-                    <div className="w-3 h-3 bg-green-500 rounded-full"></div>
+            <div className="hero-animate mx-auto max-w-3xl text-center">
+              <p className="mx-auto mb-6 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                Financial clarity in one orbit
+              </p>
+              <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+                Keep every account in sync,
+                <span
+                  ref={trackRef}
+                  className="block bg-gradient-to-r from-primary via-primary/80 to-primary/60 bg-clip-text text-transparent"
+                >
+                  every single day.
+                </span>
+              </h1>
+              <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                <div className="h-2 w-48 rounded-full bg-primary/40 sm:w-40" />
+                <div className="h-2 w-24 rounded-full bg-white/10 sm:w-32" />
+                <div className="h-2 w-16 rounded-full bg-white/10 sm:w-24" />
+              </div>
+              <p className="mx-auto mt-8 max-w-xl text-lg leading-8 text-muted-foreground">
+                Plan your month, track your daily spending, and see how each account contributes to your goals without juggling spreadsheets.
+              </p>
+            </div>
+
+            <div className="hero-animate mt-10 flex flex-col items-stretch justify-center gap-4 sm:flex-row sm:items-center">
+              <Button
+                asChild
+                size="lg"
+                className="group relative rounded-2xl px-10 py-5 text-base font-semibold shadow-lg shadow-primary/20 transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/30"
+              >
+                <Link href="/auth/sign-up" className="flex items-center gap-2">
+                  Start free trial
+                  <svg
+                    className="h-5 w-5 transition-transform group-hover:translate-x-1"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5 12h14m0 0l-6-6m6 6l-6 6"
+                      stroke="currentColor"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="1.8"
+                    />
+                  </svg>
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="rounded-2xl border-white/20 bg-white/5 px-10 py-5 text-base font-semibold text-foreground transition-transform duration-300 hover:-translate-y-1 hover:border-primary/40 hover:text-primary"
+              >
+                <Link href="#features">Explore how it works</Link>
+              </Button>
+            </div>
+
+            <div className="hero-animate mt-12 flex flex-wrap items-center justify-center gap-x-8 gap-y-4 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                Zero bank passwords needed
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-2.5 w-2.5 rounded-full bg-sky-500" />
+                End-to-end encryption
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-2.5 w-2.5 rounded-full bg-purple-500" />
+                Always free for individuals
+              </div>
+            </div>
+          </div>
+
+          <div className="hero-animate relative mt-20">
+            <div className="pointer-events-none absolute inset-x-12 -top-12 h-32 rounded-full bg-gradient-to-r from-primary/30 via-primary/10 to-primary/30 blur-3xl" />
+            <div className="flex flex-col items-center">
+              <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium uppercase tracking-[0.25em] text-muted-foreground">
+                Your accounts
+              </div>
+              <div className="relative flex items-end justify-center gap-4 sm:gap-6">
+                {accountCards.map((card) => (
+                  <div
+                    key={card.name}
+                    className="relative w-44 shrink-0 rounded-[1.75rem] border border-white/10 bg-background/80 p-5 text-left backdrop-blur-xl transition-transform duration-300 hover:z-30 hover:-translate-y-3 hover:scale-105 sm:w-52"
+                    style={card.style}
+                  >
+                    <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      <span>{card.label}</span>
+                      <span>{card.icon}</span>
+                    </div>
+                    <p className="mt-5 text-lg font-semibold text-foreground">{card.name}</p>
+                    <p className="mt-2 text-sm text-muted-foreground">Balance</p>
+                    <p className="text-2xl font-bold text-foreground">{card.balance}</p>
+                    <div className={`mt-4 h-2 rounded-full bg-gradient-to-r ${card.accent}`} />
                   </div>
-                  <div className="text-gray-400 text-sm">monli.fun</div>
-                </div>
-                <div className="bg-gray-800 rounded-2xl p-6 space-y-4">
-                  <div className="h-8 bg-primary/20 rounded-lg animate-pulse"></div>
-                  <div className="grid grid-cols-3 gap-4">
-                    <div className="h-20 bg-gray-700 rounded-xl animate-pulse delay-100"></div>
-                    <div className="h-20 bg-gray-700 rounded-xl animate-pulse delay-200"></div>
-                    <div className="h-20 bg-gray-700 rounded-xl animate-pulse delay-300"></div>
-                  </div>
-                  <div className="h-32 bg-gray-700 rounded-xl animate-pulse delay-400"></div>
-                </div>
+                ))}
               </div>
             </div>
           </div>
         </div>
       </div>
-
-      <style jsx>{`
-        @keyframes float {
-          0%,
-          100% {
-            transform: translateY(0px) rotate(0deg);
-          }
-          50% {
-            transform: translateY(-10px) rotate(1deg);
-          }
-        }
-      `}</style>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- overhaul the marketing hero section with a window-style layout that matches the provided wireframe direction
- introduce an orbit of account cards with gradients, badges, and balances to showcase multiple accounts
- refresh supporting copy, calls to action, and trust signals to align with the new presentation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cdce02c76c8325b7a8af148cad8003