### PR TITLE
Account for unbudgeted expenses in budget views

### DIFF
--- a/app/(dashboard)/budgets/page.tsx
+++ b/app/(dashboard)/budgets/page.tsx
@@ -58,7 +58,7 @@ export default function BudgetsPage() {
     setTransactions,
     loading,
     setLoading,
-    getMonthlySpending,
+    getCategorySpending,
   } = useAppStore();
 
   const [year, setYear] = useState('all');
@@ -115,7 +115,28 @@ export default function BudgetsPage() {
 
   const getBudgetTotals = (budget: Budget) => {
     const planned = budget.totalAmount;
-    const actual = getMonthlySpending(budget.month);
+    const categoryIds = new Set(
+      (budget.items ?? [])
+        .map((item) => item.categoryId)
+        .filter((id): id is string => Boolean(id))
+    );
+    const categorizedActual = (budget.items ?? []).reduce(
+      (sum, item) =>
+        sum +
+        (item.categoryId
+          ? getCategorySpending(item.categoryId, budget.month)
+          : 0),
+      0
+    );
+    const unbudgeted = transactions
+      .filter(
+        (t) =>
+          t.type === 'expense' &&
+          t.budgetMonth === budget.month &&
+          (!t.categoryId || !categoryIds.has(t.categoryId))
+      )
+      .reduce((sum, t) => sum + t.amount, 0);
+    const actual = categorizedActual + unbudgeted;
     const progress = planned ? (actual / planned) * 100 : 0;
     const indicatorColor =
       progress < 70
@@ -123,7 +144,7 @@ export default function BudgetsPage() {
         : progress <= 100
         ? 'bg-orange-500'
         : 'bg-red-500';
-    return { planned, actual, progress, indicatorColor };
+    return { planned, actual, progress, indicatorColor, unbudgeted };
   };
 
   const openBudgetDetail = (id: string) => {
@@ -132,7 +153,7 @@ export default function BudgetsPage() {
 
   // Card versi mobile/tablet, dengan tombol view lebih besar dan mudah diakses
   const renderBudgetCard = (budget: Budget) => {
-    const { planned, actual, progress, indicatorColor } =
+    const { planned, actual, progress, indicatorColor, unbudgeted } =
       getBudgetTotals(budget);
 
     return (
@@ -166,6 +187,11 @@ export default function BudgetsPage() {
             <span>Terpakai</span>
             <span>{formatIDR(actual)}</span>
           </div>
+          {unbudgeted > 0 && (
+            <p className="text-xs text-muted-foreground text-right">
+              Termasuk {formatIDR(unbudgeted)} di luar kategori anggaran
+            </p>
+          )}
           <Progress value={progress} indicatorClassName={indicatorColor} />
           <div className="text-right text-xs text-muted-foreground">
             {progress.toFixed(0)}%
@@ -247,7 +273,7 @@ export default function BudgetsPage() {
           </TableHeader>
           <TableBody>
             {filteredBudgets.map((b) => {
-              const { planned, actual, progress, indicatorColor } =
+              const { planned, actual, progress, indicatorColor, unbudgeted } =
                 getBudgetTotals(b);
               return (
                 <TableRow key={b.id}>
@@ -258,7 +284,14 @@ export default function BudgetsPage() {
                     {formatIDR(planned)}
                   </TableCell>
                   <TableCell className="text-right">
-                    {formatIDR(actual)}
+                    <div className="space-y-1">
+                      <div>{formatIDR(actual)}</div>
+                      {unbudgeted > 0 && (
+                        <div className="text-xs text-muted-foreground">
+                          Termasuk {formatIDR(unbudgeted)} di luar kategori
+                        </div>
+                      )}
+                    </div>
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-2">

--- a/components/budgets/budget-detail-dialog.tsx
+++ b/components/budgets/budget-detail-dialog.tsx
@@ -78,7 +78,6 @@ export function BudgetDetailDialog({
     loading,
     setLoading,
     getCategorySpending,
-    getMonthlySpending,
   } = useAppStore();
 
   const [budget, setBudget] = useState<Budget | null>(null);
@@ -165,8 +164,39 @@ export function BudgetDetailDialog({
     isPro,
   ]);
 
+  const budgetCategoryIds = useMemo(
+    () =>
+      new Set(
+        items
+          .map((item) => item.categoryId)
+          .filter((id): id is string => Boolean(id))
+      ),
+    [items]
+  );
+  const budgetMonth = budget?.month;
+  const categorizedSpent = budget
+    ? (budget.items ?? []).reduce(
+        (sum, item) =>
+          sum +
+          (item.categoryId
+            ? getCategorySpending(item.categoryId, budget.month)
+            : 0),
+        0
+      )
+    : 0;
+  const unbudgetedSpent = useMemo(() => {
+    if (!budgetMonth) return 0;
+    return transactions
+      .filter(
+        (t) =>
+          t.type === 'expense' &&
+          t.budgetMonth === budgetMonth &&
+          (!t.categoryId || !budgetCategoryIds.has(t.categoryId))
+      )
+      .reduce((sum, t) => sum + t.amount, 0);
+  }, [transactions, budgetMonth, budgetCategoryIds]);
   const totalBudget = budget?.totalAmount ?? 0;
-  const totalSpent = budget ? getMonthlySpending(budget.month) : 0;
+  const totalSpent = categorizedSpent + unbudgetedSpent;
   const progress = totalBudget ? (totalSpent / totalBudget) * 100 : 0;
   const overallIndicatorColor =
     progress < 70
@@ -304,6 +334,12 @@ export function BudgetDetailDialog({
                     <span>Spent</span>
                     <span className="font-medium">{formatIDR(totalSpent)}</span>
                   </div>
+                  {unbudgetedSpent > 0 && (
+                    <p className="text-xs text-muted-foreground text-right sm:text-left">
+                      Termasuk {formatIDR(unbudgetedSpent)} di luar kategori
+                      anggaran
+                    </p>
+                  )}
                   <Progress
                     value={Math.min(progress, 100)}
                     indicatorClassName={overallIndicatorColor}
@@ -410,6 +446,21 @@ export function BudgetDetailDialog({
                           </TableRow>
                         );
                       })}
+                      {unbudgetedSpent > 0 && (
+                        <TableRow>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">
+                              Pengeluaran di luar kategori anggaran
+                            </span>
+                          </TableCell>
+                          <TableCell />
+                          <TableCell className="text-right">
+                            {formatIDR(unbudgetedSpent)}
+                          </TableCell>
+                          <TableCell />
+                          {isEditing ? <TableCell /> : null}
+                        </TableRow>
+                      )}
                       {isEditing ? (
                         <TableRow>
                           <TableCell>
@@ -537,6 +588,21 @@ export function BudgetDetailDialog({
                     </Card>
                   );
                 })}
+                {unbudgetedSpent > 0 && (
+                  <Card className="bg-muted/50 w-full">
+                    <CardHeader>
+                      <CardTitle className="text-base sm:text-lg break-words">
+                        Pengeluaran di luar kategori anggaran
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2">
+                      <div className="flex flex-col gap-1 xs:flex-row xs:justify-between text-sm">
+                        <span>Spent</span>
+                        <span>{formatIDR(unbudgetedSpent)}</span>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
                 {isEditing ? (
                   <Card className="bg-muted/50 w-full">
                     <CardContent className="flex flex-col gap-2 pt-6">


### PR DESCRIPTION
## Summary
- include monthly expenses outside the configured budget categories when computing actual totals and flag them in the overview
- surface unbudgeted spending inside the budget detail dialog across the summary card, table, and mobile cards

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d33c5304388325a85a4ee8a1a48415