### PR TITLE
Align budget actuals with transaction actual dates

### DIFF
--- a/app/(dashboard)/budgets/page.tsx
+++ b/app/(dashboard)/budgets/page.tsx
@@ -12,6 +12,7 @@ import { Budget, Transaction } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { isTransactionInMonth } from '@/lib/transactions';
 import {
   Select,
   SelectContent,
@@ -58,7 +59,7 @@ export default function BudgetsPage() {
     setTransactions,
     loading,
     setLoading,
-    getMonthlySpending,
+    getCategorySpending,
   } = useAppStore();
 
   const [year, setYear] = useState('all');
@@ -115,7 +116,28 @@ export default function BudgetsPage() {
 
   const getBudgetTotals = (budget: Budget) => {
     const planned = budget.totalAmount;
-    const actual = getMonthlySpending(budget.month);
+    const categoryIds = new Set(
+      (budget.items ?? [])
+        .map((item) => item.categoryId)
+        .filter((id): id is string => Boolean(id))
+    );
+    const categorizedActual = (budget.items ?? []).reduce(
+      (sum, item) =>
+        sum +
+        (item.categoryId
+          ? getCategorySpending(item.categoryId, budget.month)
+          : 0),
+      0
+    );
+    const unbudgeted = transactions
+      .filter(
+        t =>
+          t.type === 'expense' &&
+          isTransactionInMonth(t, budget.month) &&
+          (!t.categoryId || !categoryIds.has(t.categoryId))
+      )
+      .reduce((sum, t) => sum + t.amount, 0);
+    const actual = categorizedActual + unbudgeted;
     const progress = planned ? (actual / planned) * 100 : 0;
     const indicatorColor =
       progress < 70
@@ -123,7 +145,7 @@ export default function BudgetsPage() {
         : progress <= 100
         ? 'bg-orange-500'
         : 'bg-red-500';
-    return { planned, actual, progress, indicatorColor };
+    return { planned, actual, progress, indicatorColor, unbudgeted };
   };
 
   const openBudgetDetail = (id: string) => {
@@ -132,7 +154,7 @@ export default function BudgetsPage() {
 
   // Card versi mobile/tablet, dengan tombol view lebih besar dan mudah diakses
   const renderBudgetCard = (budget: Budget) => {
-    const { planned, actual, progress, indicatorColor } =
+    const { planned, actual, progress, indicatorColor, unbudgeted } =
       getBudgetTotals(budget);
 
     return (
@@ -166,6 +188,11 @@ export default function BudgetsPage() {
             <span>Terpakai</span>
             <span>{formatIDR(actual)}</span>
           </div>
+          {unbudgeted > 0 && (
+            <p className="text-xs text-muted-foreground text-right">
+              Termasuk {formatIDR(unbudgeted)} di luar kategori anggaran
+            </p>
+          )}
           <Progress value={progress} indicatorClassName={indicatorColor} />
           <div className="text-right text-xs text-muted-foreground">
             {progress.toFixed(0)}%
@@ -247,7 +274,7 @@ export default function BudgetsPage() {
           </TableHeader>
           <TableBody>
             {filteredBudgets.map((b) => {
-              const { planned, actual, progress, indicatorColor } =
+              const { planned, actual, progress, indicatorColor, unbudgeted } =
                 getBudgetTotals(b);
               return (
                 <TableRow key={b.id}>
@@ -258,7 +285,14 @@ export default function BudgetsPage() {
                     {formatIDR(planned)}
                   </TableCell>
                   <TableCell className="text-right">
-                    {formatIDR(actual)}
+                    <div className="space-y-1">
+                      <div>{formatIDR(actual)}</div>
+                      {unbudgeted > 0 && (
+                        <div className="text-xs text-muted-foreground">
+                          Termasuk {formatIDR(unbudgeted)} di luar kategori
+                        </div>
+                      )}
+                    </div>
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-2">

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -38,6 +38,7 @@ import {
 } from 'lucide-react';
 import { formatDate } from '@/lib/date';
 import { useOffline } from '@/hooks/use-offline';
+import { isTransactionInMonth } from '@/lib/transactions';
 
 const toCamel = (str: string) =>
   str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
@@ -241,20 +242,24 @@ export default function DashboardPage() {
     const currentBudgets = budgets.filter(b => b.month === currentMonth);
 
     const monthlyIncome = transactions
-      .filter(t => t.type === 'income' && t.budgetMonth === currentMonth)
+      .filter(
+        t => t.type === 'income' && isTransactionInMonth(t, currentMonth)
+      )
       .reduce((sum, t) => sum + t.amount, 0);
 
     const monthlyExpenses = transactions
-      .filter(t => t.type === 'expense' && t.budgetMonth === currentMonth)
+      .filter(
+        t => t.type === 'expense' && isTransactionInMonth(t, currentMonth)
+      )
       .reduce((sum, t) => sum + t.amount, 0);
 
     const savings = monthlyIncome - monthlyExpenses;
 
     const prevMonthlyIncome = transactions
-      .filter(t => t.type === 'income' && t.budgetMonth === prevMonth)
+      .filter(t => t.type === 'income' && isTransactionInMonth(t, prevMonth))
       .reduce((sum, t) => sum + t.amount, 0);
     const prevMonthlyExpenses = transactions
-      .filter(t => t.type === 'expense' && t.budgetMonth === prevMonth)
+      .filter(t => t.type === 'expense' && isTransactionInMonth(t, prevMonth))
       .reduce((sum, t) => sum + t.amount, 0);
     const prevSavings = prevMonthlyIncome - prevMonthlyExpenses;
 

--- a/components/budgets/budget-detail-dialog.tsx
+++ b/components/budgets/budget-detail-dialog.tsx
@@ -37,6 +37,7 @@ import { supabase } from '@/lib/supabase';
 import { useAppStore } from '@/lib/store';
 import { formatIDR } from '@/lib/currency';
 import { Budget, BudgetItem, Category, Transaction } from '@/types';
+import { isTransactionInMonth } from '@/lib/transactions';
 
 function toCamel(str: string) {
   return str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
@@ -78,7 +79,6 @@ export function BudgetDetailDialog({
     loading,
     setLoading,
     getCategorySpending,
-    getMonthlySpending,
   } = useAppStore();
 
   const [budget, setBudget] = useState<Budget | null>(null);
@@ -165,8 +165,39 @@ export function BudgetDetailDialog({
     isPro,
   ]);
 
+  const budgetCategoryIds = useMemo(
+    () =>
+      new Set(
+        items
+          .map((item) => item.categoryId)
+          .filter((id): id is string => Boolean(id))
+      ),
+    [items]
+  );
+  const budgetMonth = budget?.month;
+  const categorizedSpent = budget
+    ? (budget.items ?? []).reduce(
+        (sum, item) =>
+          sum +
+          (item.categoryId
+            ? getCategorySpending(item.categoryId, budget.month)
+            : 0),
+        0
+      )
+    : 0;
+  const unbudgetedSpent = useMemo(() => {
+    if (!budgetMonth) return 0;
+    return transactions
+      .filter(
+        t =>
+          t.type === 'expense' &&
+          isTransactionInMonth(t, budgetMonth) &&
+          (!t.categoryId || !budgetCategoryIds.has(t.categoryId))
+      )
+      .reduce((sum, t) => sum + t.amount, 0);
+  }, [transactions, budgetMonth, budgetCategoryIds]);
   const totalBudget = budget?.totalAmount ?? 0;
-  const totalSpent = budget ? getMonthlySpending(budget.month) : 0;
+  const totalSpent = categorizedSpent + unbudgetedSpent;
   const progress = totalBudget ? (totalSpent / totalBudget) * 100 : 0;
   const overallIndicatorColor =
     progress < 70
@@ -304,6 +335,12 @@ export function BudgetDetailDialog({
                     <span>Spent</span>
                     <span className="font-medium">{formatIDR(totalSpent)}</span>
                   </div>
+                  {unbudgetedSpent > 0 && (
+                    <p className="text-xs text-muted-foreground text-right sm:text-left">
+                      Termasuk {formatIDR(unbudgetedSpent)} di luar kategori
+                      anggaran
+                    </p>
+                  )}
                   <Progress
                     value={Math.min(progress, 100)}
                     indicatorClassName={overallIndicatorColor}
@@ -410,6 +447,21 @@ export function BudgetDetailDialog({
                           </TableRow>
                         );
                       })}
+                      {unbudgetedSpent > 0 && (
+                        <TableRow>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">
+                              Pengeluaran di luar kategori anggaran
+                            </span>
+                          </TableCell>
+                          <TableCell />
+                          <TableCell className="text-right">
+                            {formatIDR(unbudgetedSpent)}
+                          </TableCell>
+                          <TableCell />
+                          {isEditing ? <TableCell /> : null}
+                        </TableRow>
+                      )}
                       {isEditing ? (
                         <TableRow>
                           <TableCell>
@@ -537,6 +589,21 @@ export function BudgetDetailDialog({
                     </Card>
                   );
                 })}
+                {unbudgetedSpent > 0 && (
+                  <Card className="bg-muted/50 w-full">
+                    <CardHeader>
+                      <CardTitle className="text-base sm:text-lg break-words">
+                        Pengeluaran di luar kategori anggaran
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2">
+                      <div className="flex flex-col gap-1 xs:flex-row xs:justify-between text-sm">
+                        <span>Spent</span>
+                        <span>{formatIDR(unbudgetedSpent)}</span>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
                 {isEditing ? (
                   <Card className="bg-muted/50 w-full">
                     <CardContent className="flex flex-col gap-2 pt-6">

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { User, Account, Category, Transaction, Budget } from '@/types';
+import { isTransactionInMonth } from './transactions';
 
 // Check if we're in browser environment
 const isBrowser = typeof window !== 'undefined';
@@ -93,10 +94,10 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { transactions } = get();
     return transactions
       .filter(
-        (t) =>
+        t =>
           t.categoryId === categoryId &&
           t.type === 'expense' &&
-          t.budgetMonth === month
+          isTransactionInMonth(t, month)
       )
       .reduce((sum, t) => sum + t.amount, 0);
   },
@@ -104,9 +105,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   getMonthlySpending: (month: string) => {
     const { transactions } = get();
     return transactions
-      .filter(
-        (t) => t.type === 'expense' && t.budgetMonth === month
-      )
+      .filter(t => t.type === 'expense' && isTransactionInMonth(t, month))
       .reduce((sum, t) => sum + t.amount, 0);
   },
 }));

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -1,0 +1,26 @@
+import { format, parseISO } from 'date-fns';
+
+import type { Transaction } from '@/types';
+
+const MONTH_FORMAT = 'yyyy-MM';
+
+export function getTransactionMonth(transaction: Transaction): string {
+  const { actualDate, budgetMonth } = transaction;
+
+  if (actualDate) {
+    const parsedDate = parseISO(actualDate);
+    if (!Number.isNaN(parsedDate.getTime())) {
+      return format(parsedDate, MONTH_FORMAT);
+    }
+  }
+
+  return budgetMonth;
+}
+
+export function isTransactionInMonth(
+  transaction: Transaction,
+  month: string
+): boolean {
+  if (!month) return false;
+  return getTransactionMonth(transaction) === month;
+}


### PR DESCRIPTION
## Summary
- add transaction date helpers to derive the reporting month from actual transaction timestamps
- ensure the budget store and pages use the actual transaction month when aggregating categorized and uncategorized expenses
- update dashboard KPIs to rely on the same month logic for monthly income, expense, and savings totals

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d33c5304388325a85a4ee8a1a48415