### PR TITLE
Fix currency formatting for non-IDR totals

### DIFF
--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -18,12 +18,10 @@ export function formatCurrency(amount: number, currency = 'IDR'): string {
   if (currency === 'IDR') {
     return formatIDR(amount);
   }
-  
+
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
+    currency,
   }).format(amount);
 }
 


### PR DESCRIPTION
## Summary
- allow non-IDR currencies to use their default fractional digits when formatted

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d9180e6148325916f88cad0d52404)